### PR TITLE
Add preview window, status billboard, and timestamp-aware muxing

### DIFF
--- a/Plugins/PanoramaCapture/PanoramaCapture.uplugin
+++ b/Plugins/PanoramaCapture/PanoramaCapture.uplugin
@@ -1,0 +1,50 @@
+{
+  "FileVersion": 3,
+  "Version": 1,
+  "VersionName": "1.0.0",
+  "FriendlyName": "Panorama Capture",
+  "Description": "High-performance cubemap to equirectangular capture plugin with NVENC output and PNG pipelines.",
+  "Category": "Rendering",
+  "CreatedBy": "OpenAI",
+  "CreatedByURL": "https://openai.com",
+  "DocsURL": "",
+  "MarketplaceURL": "",
+  "SupportURL": "",
+  "CanContainContent": true,
+  "IsBetaVersion": true,
+  "IsExperimentalVersion": true,
+  "Installed": false,
+  "Modules": [
+    {
+      "Name": "PanoramaCapture",
+      "Type": "Runtime",
+      "LoadingPhase": "Default"
+    },
+    {
+      "Name": "PanoramaCaptureEditor",
+      "Type": "Editor",
+      "LoadingPhase": "Default"
+    },
+    {
+      "Name": "PanoramaCaptureNVENC",
+      "Type": "Runtime",
+      "LoadingPhase": "Default",
+      "WhitelistPlatforms": [
+        "Win64"
+      ]
+    }
+  ],
+  "Plugins": [
+    {
+      "Name": "AudioMixer",
+      "Enabled": true
+    }
+  ],
+  "SupportedTargetPlatforms": [
+    "Win64"
+  ],
+  "EngineVersion": "5.4.0",
+  "TargetPlatforms": [
+    "Win64"
+  ]
+}

--- a/Plugins/PanoramaCapture/Shaders/Private/CubemapToEquirect.usf
+++ b/Plugins/PanoramaCapture/Shaders/Private/CubemapToEquirect.usf
@@ -1,0 +1,76 @@
+#include "/Engine/Public/Platform.ush"
+
+RWTexture2D<float4> RWOutputTexture;
+TextureCube<float4> SourceTextureLeft;
+TextureCube<float4> SourceTextureRight;
+SamplerState SourceSampler;
+
+cbuffer FCubemapToEquirectParameters
+{
+    float2 OutputResolution;
+    uint bStereo;
+    uint bLinear;
+    uint bStereoOverUnder;
+};
+
+float3 DirectionFromEquirect(float2 InUV)
+{
+    const float Phi = InUV.x * (2.0f * PI) - PI;
+    const float Theta = InUV.y * PI - (PI * 0.5f);
+    const float CosTheta = cos(Theta);
+    return float3(cos(Phi) * CosTheta, sin(Theta), sin(Phi) * CosTheta);
+}
+
+[numthreads(8, 8, 1)]
+void MainCS(uint3 DispatchThreadId : SV_DispatchThreadID)
+{
+    if (DispatchThreadId.x >= (uint)OutputResolution.x || DispatchThreadId.y >= (uint)OutputResolution.y)
+    {
+        return;
+    }
+
+    float2 OutputUV = (float2(DispatchThreadId.xy) + 0.5f) / OutputResolution;
+    float2 SampleUV = OutputUV;
+    uint EyeIndex = 0;
+
+    if (bStereo != 0)
+    {
+        if (bStereoOverUnder != 0)
+        {
+            if (OutputUV.y >= 0.5f)
+            {
+                EyeIndex = 1;
+                SampleUV.y = (OutputUV.y - 0.5f) * 2.0f;
+            }
+            else
+            {
+                SampleUV.y = OutputUV.y * 2.0f;
+            }
+        }
+        else
+        {
+            if (OutputUV.x >= 0.5f)
+            {
+                EyeIndex = 1;
+                SampleUV.x = (OutputUV.x - 0.5f) * 2.0f;
+            }
+            else
+            {
+                SampleUV.x = OutputUV.x * 2.0f;
+            }
+        }
+    }
+
+    SampleUV = saturate(SampleUV);
+
+    float3 Direction = DirectionFromEquirect(SampleUV);
+    float4 Sample = (EyeIndex == 0 ? SourceTextureLeft.SampleLevel(SourceSampler, Direction, 0.0f) : SourceTextureRight.SampleLevel(SourceSampler, Direction, 0.0f));
+
+    if (bLinear == 0)
+    {
+        Sample.rgb = pow(saturate(Sample.rgb), 1.0f / 2.2f);
+    }
+
+    uint2 OutputCoords = uint2(OutputUV * OutputResolution);
+    RWOutputTexture[OutputCoords] = Sample;
+}

--- a/Plugins/PanoramaCapture/Shaders/Private/EncodeSurface.usf
+++ b/Plugins/PanoramaCapture/Shaders/Private/EncodeSurface.usf
@@ -1,0 +1,32 @@
+#include "/Engine/Public/Platform.ush"
+
+Texture2D<float4> SourceTexture;
+RWTexture2D<float4> OutputTexture;
+
+cbuffer FEncodeSurfaceParameters
+{
+    uint bApplySRGB;
+};
+
+[numthreads(8, 8, 1)]
+void MainCS(uint3 DispatchThreadId : SV_DispatchThreadID)
+{
+    uint Width;
+    uint Height;
+    SourceTexture.GetDimensions(Width, Height);
+
+    if (DispatchThreadId.x >= Width || DispatchThreadId.y >= Height)
+    {
+        return;
+    }
+
+    float4 Sample = SourceTexture.Load(int3(DispatchThreadId.xy, 0));
+    float3 Color = saturate(Sample.rgb);
+
+    if (bApplySRGB != 0)
+    {
+        Color = pow(Color, 1.0f / 2.2f);
+    }
+
+    OutputTexture[DispatchThreadId.xy] = float4(Color, saturate(Sample.a));
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/PanoramaCapture.Build.cs
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/PanoramaCapture.Build.cs
@@ -1,0 +1,45 @@
+using UnrealBuildTool;
+
+public class PanoramaCapture : ModuleRules
+{
+    public PanoramaCapture(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+
+        PublicDependencyModuleNames.AddRange(new[]
+        {
+            "Core",
+            "CoreUObject",
+            "Engine",
+            "RenderCore",
+            "RHI",
+            "Projects",
+            "Slate",
+            "SlateCore"
+        });
+
+        PrivateDependencyModuleNames.AddRange(new[]
+        {
+            "InputCore",
+            "CinematicCamera",
+            "DeveloperSettings",
+            "AudioMixer",
+            "ImageWrapper",
+            "SignalProcessing",
+            "MovieScene",
+            "MovieSceneTracks",
+            "TimeManagement"
+        });
+
+        if (Target.Platform == UnrealTargetPlatform.Win64)
+        {
+            PrivateDependencyModuleNames.Add("D3D12RHI");
+            PrivateDependencyModuleNames.Add("D3D11RHI");
+            PublicDefinitions.Add("WITH_PANORAMA_NVENC=1");
+        }
+        else
+        {
+            PublicDefinitions.Add("WITH_PANORAMA_NVENC=0");
+        }
+    }
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/CaptureFrameQueue.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/CaptureFrameQueue.cpp
@@ -1,0 +1,199 @@
+#include "CaptureFrameQueue.h"
+
+#include "HAL/Event.h"
+#include "HAL/PlatformProcess.h"
+#include "Misc/ScopeLock.h"
+
+FCaptureFrameRingBuffer::FCaptureFrameRingBuffer()
+    : Head(0)
+    , Tail(0)
+    , CurrentSize(0)
+    , MaxCapacity(0)
+    , DroppedFrames(0)
+    , BlockedEnqueues(0)
+    , OverflowPolicy(ERingBufferOverflowPolicy::DropOldest)
+    , NotEmptyEvent(nullptr)
+    , NotFullEvent(nullptr)
+{
+}
+
+FCaptureFrameRingBuffer::~FCaptureFrameRingBuffer()
+{
+    Clear();
+}
+
+void FCaptureFrameRingBuffer::Initialize(int32 InCapacity, ERingBufferOverflowPolicy InPolicy)
+{
+    FScopeLock Lock(&CriticalSection);
+    MaxCapacity = FMath::Max(1, InCapacity);
+    Frames.SetNum(MaxCapacity);
+    Head = 0;
+    Tail = 0;
+    CurrentSize = 0;
+    DroppedFrames = 0;
+    BlockedEnqueues = 0;
+    OverflowPolicy = InPolicy;
+
+    if (!NotEmptyEvent)
+    {
+        NotEmptyEvent = FPlatformProcess::GetSynchEventFromPool(false);
+    }
+    if (!NotFullEvent)
+    {
+        NotFullEvent = FPlatformProcess::GetSynchEventFromPool(false);
+    }
+
+    if (NotFullEvent)
+    {
+        NotFullEvent->Trigger();
+    }
+}
+
+void FCaptureFrameRingBuffer::Clear()
+{
+    FScopeLock Lock(&CriticalSection);
+    Frames.Empty();
+    Head = 0;
+    Tail = 0;
+    CurrentSize = 0;
+    DroppedFrames = 0;
+    BlockedEnqueues = 0;
+    MaxCapacity = 0;
+    OverflowPolicy = ERingBufferOverflowPolicy::DropOldest;
+
+    if (NotEmptyEvent)
+    {
+        FPlatformProcess::ReturnSynchEventToPool(NotEmptyEvent);
+        NotEmptyEvent = nullptr;
+    }
+    if (NotFullEvent)
+    {
+        FPlatformProcess::ReturnSynchEventToPool(NotFullEvent);
+        NotFullEvent = nullptr;
+    }
+}
+
+bool FCaptureFrameRingBuffer::Enqueue(FPanoramaCaptureFrame&& Frame)
+{
+    while (true)
+    {
+        CriticalSection.Lock();
+
+        if (MaxCapacity <= 0)
+        {
+            ++DroppedFrames;
+            CriticalSection.Unlock();
+            return false;
+        }
+
+        if (Frames.Num() != MaxCapacity)
+        {
+            Frames.SetNum(MaxCapacity);
+        }
+
+        if (CurrentSize < MaxCapacity)
+        {
+            Frames[Tail] = MoveTemp(Frame);
+            Tail = (Tail + 1) % MaxCapacity;
+            ++CurrentSize;
+            CriticalSection.Unlock();
+
+            if (NotEmptyEvent)
+            {
+                NotEmptyEvent->Trigger();
+            }
+
+            return true;
+        }
+
+        // Buffer full
+        if (OverflowPolicy == ERingBufferOverflowPolicy::DropOldest)
+        {
+            Head = (Head + 1) % MaxCapacity;
+            --CurrentSize;
+            ++DroppedFrames;
+            Frames[Tail] = MoveTemp(Frame);
+            Tail = (Tail + 1) % MaxCapacity;
+            ++CurrentSize;
+            CriticalSection.Unlock();
+
+            if (NotEmptyEvent)
+            {
+                NotEmptyEvent->Trigger();
+            }
+
+            return true;
+        }
+
+        if (OverflowPolicy == ERingBufferOverflowPolicy::DropNewest)
+        {
+            ++DroppedFrames;
+            CriticalSection.Unlock();
+            return false;
+        }
+
+        // Block until consumer frees space
+        ++BlockedEnqueues;
+        if (NotFullEvent)
+        {
+            NotFullEvent->Reset();
+        }
+        CriticalSection.Unlock();
+
+        if (NotFullEvent)
+        {
+            NotFullEvent->Wait();
+        }
+        else
+        {
+            FPlatformProcess::Sleep(0.001f);
+        }
+    }
+}
+
+bool FCaptureFrameRingBuffer::Dequeue(FPanoramaCaptureFrame& OutFrame)
+{
+    CriticalSection.Lock();
+
+    if (CurrentSize == 0)
+    {
+        CriticalSection.Unlock();
+        return false;
+    }
+
+    OutFrame = MoveTemp(Frames[Head]);
+    Head = (Head + 1) % MaxCapacity;
+    --CurrentSize;
+
+    if (NotFullEvent)
+    {
+        NotFullEvent->Trigger();
+    }
+
+    CriticalSection.Unlock();
+    return true;
+}
+
+int32 FCaptureFrameRingBuffer::Num() const
+{
+    FScopeLock Lock(&CriticalSection);
+    return CurrentSize;
+}
+
+int32 FCaptureFrameRingBuffer::Capacity() const
+{
+    FScopeLock Lock(&CriticalSection);
+    return MaxCapacity;
+}
+
+int32 FCaptureFrameRingBuffer::GetDroppedFrames() const
+{
+    FScopeLock Lock(&CriticalSection);
+    return DroppedFrames;
+}
+
+int32 FCaptureFrameRingBuffer::GetBlockedFrames() const
+{
+    FScopeLock Lock(&CriticalSection);
+    return BlockedEnqueues;
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/CaptureOutputSettings.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/CaptureOutputSettings.cpp
@@ -1,0 +1,12 @@
+#include "CaptureOutputSettings.h"
+
+UPanoramaCaptureSettings::UPanoramaCaptureSettings()
+{
+    CategoryName = TEXT("Plugins");
+    SectionName = TEXT("PanoramaCapture");
+    NVENCProfile = TEXT("main10");
+    AudioSubmix = NAME_None;
+    DefaultOutputDirectory = TEXT("PanoramaCaptures");
+    bDefaultAutoAssemble = true;
+    FFmpegExecutable = TEXT("");
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/CubemapCaptureRigComponent.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/CubemapCaptureRigComponent.cpp
@@ -1,0 +1,231 @@
+#include "CubemapCaptureRigComponent.h"
+
+#include "Camera/CameraTypes.h"
+#include "Engine/TextureRenderTarget2D.h"
+
+namespace
+{
+    constexpr int32 FacesPerEye = 6;
+
+    const FRotator FaceRotations[FacesPerEye] = {
+        FRotator(0.f, 90.f, 0.f),   // +X
+        FRotator(0.f, -90.f, 0.f),  // -X
+        FRotator(-90.f, 0.f, 0.f),  // +Y
+        FRotator(90.f, 0.f, 0.f),   // -Y
+        FRotator(0.f, 0.f, 0.f),    // +Z (forward)
+        FRotator(0.f, 180.f, 0.f)   // -Z (back)
+    };
+
+    const TCHAR* FaceNames[FacesPerEye] = {
+        TEXT("+X"),
+        TEXT("-X"),
+        TEXT("+Y"),
+        TEXT("-Y"),
+        TEXT("+Z"),
+        TEXT("-Z")
+    };
+}
+
+UCubemapCaptureRigComponent::UCubemapCaptureRigComponent()
+{
+    PrimaryComponentTick.bCanEverTick = true;
+    PrimaryComponentTick.bStartWithTickEnabled = true;
+
+    bStereo = false;
+    NearClipPlane = 10.f;
+    FarClipPlane = 500000.f;
+
+    if (Faces.Num() == 0)
+    {
+        for (int32 FaceIndex = 0; FaceIndex < FacesPerEye; ++FaceIndex)
+        {
+            FPanoramaCaptureFace Face;
+            Face.Name = FName(FaceNames[FaceIndex]);
+            Face.Rotation = FaceRotations[FaceIndex];
+            Face.DebugColor = FColor::MakeRandomColor();
+            Faces.Add(Face);
+        }
+    }
+}
+
+void UCubemapCaptureRigComponent::OnRegister()
+{
+    Super::OnRegister();
+    InitializeRig();
+}
+
+void UCubemapCaptureRigComponent::OnUnregister()
+{
+    ReleaseRig();
+    Super::OnUnregister();
+}
+
+void UCubemapCaptureRigComponent::InitializeRig()
+{
+    const int32 EyeCount = bStereo ? 2 : 1;
+    const int32 RequiredFaces = EyeCount * FacesPerEye;
+    FaceCaptures.Reserve(RequiredFaces);
+    EyeRenderTargets.SetNum(RequiredFaces);
+
+    for (int32 EyeIndex = 0; EyeIndex < EyeCount; ++EyeIndex)
+    {
+        EnsureFaceCaptures(EyeIndex);
+    }
+
+    UpdateCaptureTransforms();
+}
+
+void UCubemapCaptureRigComponent::ReleaseRig()
+{
+    for (TObjectPtr<USceneCaptureComponent2D>& Capture : FaceCaptures)
+    {
+        if (Capture)
+        {
+            Capture->DestroyComponent();
+        }
+    }
+    FaceCaptures.Empty();
+    EyeRenderTargets.Empty();
+}
+
+void UCubemapCaptureRigComponent::TickRig(float DeltaTime)
+{
+    if (!IsRegistered())
+    {
+        return;
+    }
+
+    UpdateCaptureTransforms();
+
+    for (TObjectPtr<USceneCaptureComponent2D>& Capture : FaceCaptures)
+    {
+        if (Capture)
+        {
+            Capture->CaptureScene();
+        }
+    }
+}
+
+UTextureRenderTarget2D* UCubemapCaptureRigComponent::GetFaceRenderTarget(int32 FaceIndex, bool bLeftEye) const
+{
+    const int32 EyeIndex = bLeftEye ? 0 : (bStereo ? 1 : 0);
+    const int32 Index = EyeIndex * FacesPerEye + FaceIndex;
+    if (EyeRenderTargets.IsValidIndex(Index))
+    {
+        return EyeRenderTargets[Index].Get();
+    }
+    return nullptr;
+}
+
+void UCubemapCaptureRigComponent::SetCaptureMaterial(UMaterialInterface* OverrideMaterial)
+{
+    CaptureMaterial = OverrideMaterial;
+    for (TObjectPtr<USceneCaptureComponent2D>& Capture : FaceCaptures)
+    {
+        if (Capture)
+        {
+            Capture->PostProcessSettings.bOverride_AutoExposureMethod = true;
+            Capture->PostProcessSettings.AutoExposureMethod = EAutoExposureMethod::AEM_Manual;
+            Capture->PostProcessSettings.bOverride_ColorGradingLUT = (CaptureMaterial != nullptr);
+            Capture->PostProcessSettings.AddBlendable(CaptureMaterial, 1.0f);
+        }
+    }
+}
+
+void UCubemapCaptureRigComponent::EnsureFaceCaptures(int32 EyeIndex)
+{
+    const int32 StartIndex = EyeIndex * FacesPerEye;
+    const int32 RequiredFaces = StartIndex + FacesPerEye;
+
+    if (FaceCaptures.Num() < RequiredFaces)
+    {
+        FaceCaptures.SetNum(RequiredFaces);
+    }
+
+    if (EyeRenderTargets.Num() < RequiredFaces)
+    {
+        EyeRenderTargets.SetNum(RequiredFaces);
+    }
+
+    for (int32 FaceIndex = 0; FaceIndex < FacesPerEye; ++FaceIndex)
+    {
+        const int32 CaptureIndex = StartIndex + FaceIndex;
+        TObjectPtr<USceneCaptureComponent2D>& Capture = FaceCaptures[CaptureIndex];
+
+        if (!Capture)
+        {
+            Capture = NewObject<USceneCaptureComponent2D>(GetOwner());
+            Capture->AttachToComponent(this, FAttachmentTransformRules::SnapToTargetIncludingScale);
+            Capture->SetRelativeLocation(FVector::ZeroVector);
+            Capture->SetRelativeRotation(FRotator::ZeroRotator);
+            Capture->RegisterComponent();
+            ConfigureCaptureComponent(Capture);
+        }
+
+        const EPixelFormat PixelFormat = OutputSettings.bUse16BitPNG ? PF_FloatRGBA : PF_B8G8R8A8;
+        const int32 Width = OutputSettings.Resolution.Width;
+        const int32 Height = OutputSettings.Resolution.Height;
+        UTextureRenderTarget2D* RenderTarget = EyeRenderTargets[CaptureIndex].Get();
+        if (!RenderTarget)
+        {
+            RenderTarget = NewObject<UTextureRenderTarget2D>(this);
+            RenderTarget->ClearColor = FLinearColor::Black;
+            EyeRenderTargets[CaptureIndex] = RenderTarget;
+        }
+
+        if (RenderTarget->SizeX != Width || RenderTarget->SizeY != Height || RenderTarget->OverrideFormat != PixelFormat)
+        {
+            RenderTarget->InitCustomFormat(Width, Height, PixelFormat, false);
+            RenderTarget->TargetGamma = (OutputSettings.GammaSpace == EPanoramaGammaSpace::Linear) ? 1.0f : 2.2f;
+            RenderTarget->UpdateResourceImmediate(true);
+        }
+
+        if (Capture)
+        {
+            Capture->TextureTarget = RenderTarget;
+        }
+    }
+}
+
+void UCubemapCaptureRigComponent::UpdateCaptureTransforms()
+{
+    const int32 EyeCount = bStereo ? 2 : 1;
+    for (int32 EyeIndex = 0; EyeIndex < EyeCount; ++EyeIndex)
+    {
+        const float EyeOffset = (EyeCount > 1) ? ((EyeIndex == 0) ? -0.032f : 0.032f) : 0.0f;
+        const FVector EyeTranslation = GetRightVector() * EyeOffset;
+
+        for (int32 FaceIndex = 0; FaceIndex < FacesPerEye; ++FaceIndex)
+        {
+            const int32 CaptureIndex = EyeIndex * FacesPerEye + FaceIndex;
+            if (FaceCaptures.IsValidIndex(CaptureIndex))
+            {
+                if (USceneCaptureComponent2D* Capture = FaceCaptures[CaptureIndex])
+                {
+                    const FRotator DesiredRotation = Faces.IsValidIndex(FaceIndex) ? Faces[FaceIndex].Rotation : FaceRotations[FaceIndex];
+                    Capture->SetWorldLocation(GetComponentLocation() + EyeTranslation);
+                    Capture->SetWorldRotation(DesiredRotation + GetComponentRotation());
+                }
+            }
+        }
+    }
+}
+
+void UCubemapCaptureRigComponent::ConfigureCaptureComponent(USceneCaptureComponent2D* Capture) const
+{
+    if (!Capture)
+    {
+        return;
+    }
+
+    Capture->bCaptureEveryFrame = false;
+    Capture->CaptureSource = ESceneCaptureSource::SCS_FinalColorHDR;
+    Capture->FOVAngle = 90.f;
+    Capture->ClipPlaneNear = NearClipPlane;
+    Capture->ClipPlaneFar = FarClipPlane;
+    Capture->bEnableClipPlane = false;
+    Capture->PrimitiveRenderMode = ESceneCapturePrimitiveRenderMode::PRM_RenderScenePrimitives;
+    Capture->CompositeMode = ESceneCaptureCompositeMode::SCCM_Overwrite;
+    Capture->PostProcessSettings.bOverride_AutoExposureMethod = true;
+    Capture->PostProcessSettings.AutoExposureMethod = EAutoExposureMethod::AEM_Manual;
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/CubemapEquirectPass.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/CubemapEquirectPass.cpp
@@ -1,0 +1,69 @@
+#include "CubemapEquirectPass.h"
+
+#include "GlobalShader.h"
+#include "PanoramaCaptureModule.h"
+#include "RenderGraphBuilder.h"
+#include "RenderGraphUtils.h"
+#include "RenderGraphResources.h"
+#include "ShaderParameterStruct.h"
+#include "ShaderParameterUtils.h"
+#include "ShaderCompilerCore.h"
+#include "ComputeShaderUtils.h"
+
+class FCubemapToEquirectCS : public FGlobalShader
+{
+public:
+    DECLARE_GLOBAL_SHADER(FCubemapToEquirectCS);
+    SHADER_USE_PARAMETER_STRUCT(FCubemapToEquirectCS, FGlobalShader);
+
+    static bool ShouldCompilePermutation(const FGlobalShaderPermutationParameters& Parameters)
+    {
+        return Parameters.Platform == SP_PCD3D_SM5 || Parameters.Platform == SP_METAL_SM5 || Parameters.Platform == SP_VULKAN_SM5;
+    }
+
+    static void ModifyCompilationEnvironment(const FGlobalShaderPermutationParameters& Parameters, FShaderCompilerEnvironment& OutEnvironment)
+    {
+        FGlobalShader::ModifyCompilationEnvironment(Parameters, OutEnvironment);
+        OutEnvironment.SetDefine(TEXT("PANORAMA_LINEAR_GAMMA"), 1);
+    }
+
+    BEGIN_SHADER_PARAMETER_STRUCT(FParameters, )
+        SHADER_PARAMETER(FVector2f, OutputResolution)
+        SHADER_PARAMETER(uint32, bStereo)
+        SHADER_PARAMETER(uint32, bLinear)
+        SHADER_PARAMETER(uint32, bStereoOverUnder)
+        SHADER_PARAMETER_RDG_TEXTURE(TextureCube, SourceTextureLeft)
+        SHADER_PARAMETER_RDG_TEXTURE(TextureCube, SourceTextureRight)
+        SHADER_PARAMETER_SAMPLER(SamplerState, SourceSampler)
+        SHADER_PARAMETER_RDG_TEXTURE_UAV(RWTexture2D<float4>, OutputTexture)
+    END_SHADER_PARAMETER_STRUCT()
+};
+
+IMPLEMENT_GLOBAL_SHADER(FCubemapToEquirectCS, "/PanoramaCapture/Private/CubemapToEquirect.usf", "MainCS", SF_Compute);
+
+void FCubemapEquirectPass::AddComputePass(FRDGBuilder& GraphBuilder, const FCubemapEquirectDispatchParams& Params)
+{
+    if (!Params.SourceCubemapLeft || !Params.DestinationEquirect)
+    {
+        return;
+    }
+
+    FCubemapToEquirectCS::FParameters* PassParameters = GraphBuilder.AllocParameters<FCubemapToEquirectCS::FParameters>();
+    PassParameters->SourceTextureLeft = Params.SourceCubemapLeft;
+    PassParameters->SourceTextureRight = Params.SourceCubemapRight ? Params.SourceCubemapRight : Params.SourceCubemapLeft;
+    PassParameters->SourceSampler = TStaticSamplerState<SF_Bilinear, AM_Clamp, AM_Clamp, AM_Clamp>::GetRHI();
+    PassParameters->OutputTexture = GraphBuilder.CreateUAV(Params.DestinationEquirect);
+    PassParameters->OutputResolution = FVector2f(Params.OutputResolution);
+    PassParameters->bStereo = Params.bStereo ? 1u : 0u;
+    PassParameters->bLinear = Params.bLinearGamma ? 1u : 0u;
+    PassParameters->bStereoOverUnder = Params.bStereoOverUnder ? 1u : 0u;
+
+    TShaderMapRef<FCubemapToEquirectCS> ComputeShader(GetGlobalShaderMap(GMaxRHIFeatureLevel));
+
+    const FIntVector GroupCount(
+        FMath::DivideAndRoundUp(Params.OutputResolution.X, 8),
+        FMath::DivideAndRoundUp(Params.OutputResolution.Y, 8),
+        1);
+
+    FComputeShaderUtils::AddPass(GraphBuilder, RDG_EVENT_NAME("Panorama::CubemapToEquirect"), ComputeShader, PassParameters, GroupCount);
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureController.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureController.cpp
@@ -1,0 +1,1164 @@
+#include "PanoramaCaptureController.h"
+
+#include "Async/Async.h"
+#include "AudioMixerBlueprintLibrary.h"
+#include "CaptureOutputSettings.h"
+#include "CubemapCaptureRigComponent.h"
+#include "CubemapEquirectPass.h"
+#include "Containers/StringBuilder.h"
+#include "Engine/Texture2D.h"
+#include "Engine/TextureRenderTarget2D.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include "HAL/FileManager.h"
+#include "HAL/PlatformFilemanager.h"
+#include "HAL/PlatformProcess.h"
+#include "Components/TextRenderComponent.h"
+#include "IImageWrapper.h"
+#include "IImageWrapperModule.h"
+#include "Misc/DateTime.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "Modules/ModuleManager.h"
+#include "PanoramaCaptureModule.h"
+#include "ComputeShaderUtils.h"
+#include "GlobalShader.h"
+#include "RenderGraphBuilder.h"
+#include "RenderGraphResources.h"
+#include "RenderGraphUtils.h"
+#include "RenderTargetPool.h"
+#include "RHICommandList.h"
+#include "RHIResources.h"
+#include "RenderingThread.h"
+#include "ShaderParameterStruct.h"
+#include "ShaderParameterUtils.h"
+#include "Sound/SoundSubmixBase.h"
+#include "Sound/SoundWave.h"
+#include "TimerManager.h"
+#include "TextureResource.h"
+#include "UObject/Package.h"
+
+namespace
+{
+    constexpr int32 FacesPerEye = 6;
+
+    FString SanitizeFileComponent(const FString& Input)
+    {
+        FString Result = Input;
+        static const TCHAR* InvalidCharacters[] = { TEXT("<"), TEXT(">"), TEXT(":"), TEXT("\""), TEXT("/"), TEXT("\\"), TEXT("|"), TEXT("?"), TEXT("*") };
+        for (const TCHAR* InvalidCharacter : InvalidCharacters)
+        {
+            Result.ReplaceInline(InvalidCharacter, TEXT("_"));
+        }
+        Result.TrimStartAndEndInline();
+        if (Result.IsEmpty())
+        {
+            Result = TEXT("PanoramaCapture");
+        }
+        return Result;
+    }
+
+#if WITH_PANORAMA_NVENC
+    class FEncodeSurfaceCS : public FGlobalShader
+    {
+    public:
+        DECLARE_GLOBAL_SHADER(FEncodeSurfaceCS);
+        SHADER_USE_PARAMETER_STRUCT(FEncodeSurfaceCS, FGlobalShader);
+
+        static bool ShouldCompilePermutation(const FGlobalShaderPermutationParameters& Parameters)
+        {
+#if PLATFORM_WINDOWS
+            return Parameters.Platform == SP_PCD3D_SM5;
+#else
+            return false;
+#endif
+        }
+
+        BEGIN_SHADER_PARAMETER_STRUCT(FParameters, )
+            SHADER_PARAMETER_RDG_TEXTURE(Texture2D<float4>, SourceTexture)
+            SHADER_PARAMETER_RDG_TEXTURE_UAV(RWTexture2D<float4>, OutputTexture)
+            SHADER_PARAMETER(uint32, bApplySRGB)
+        END_SHADER_PARAMETER_STRUCT()
+    };
+#endif // WITH_PANORAMA_NVENC
+
+class FPendingCapturePayload : public TSharedFromThis<FPendingCapturePayload, ESPMode::ThreadSafe>
+    {
+    public:
+        FPendingCapturePayload(const FCaptureOutputSettings& InSettings, FIntPoint InResolution, double InTimeSeconds, int32 InFrameIndex, const FString& InOutputFile, bool bInPreviewOnly)
+            : Settings(InSettings)
+            , Resolution(InResolution)
+            , TimeSeconds(InTimeSeconds)
+            , FrameIndex(InFrameIndex)
+            , OutputFile(InOutputFile)
+            , Readback(MakeUnique<FRHIGPUTextureReadback>(TEXT("PanoramaCaptureReadback")))
+            , bPreviewOnly(bInPreviewOnly)
+        {
+        }
+
+        FRHIGPUTextureReadback* GetReadback() const
+        {
+            return Readback.Get();
+        }
+
+        bool IsReady() const
+        {
+            return Readback && Readback->IsReady();
+        }
+
+        FPanoramaCaptureFrame Resolve()
+        {
+            check(IsReady());
+
+            const int32 Width = Resolution.X;
+            const int32 Height = Resolution.Y;
+            const bool bUse16BitPNG = Settings.bUse16BitPNG;
+
+            TArray<uint8> Payload;
+            Payload.SetNumUninitialized(Width * Height * (bUse16BitPNG ? sizeof(uint16) * 4 : 4));
+
+            int32 RowPitch = 0;
+            const uint8* SourceData = static_cast<const uint8*>(Readback->Lock(RowPitch));
+
+            if (bUse16BitPNG)
+            {
+                uint16* DestData = reinterpret_cast<uint16*>(Payload.GetData());
+                for (int32 Y = 0; Y < Height; ++Y)
+                {
+                    const float* SrcRow = reinterpret_cast<const float*>(SourceData + Y * RowPitch);
+                    for (int32 X = 0; X < Width; ++X)
+                    {
+                        const int32 SrcIndex = X * 4;
+                        const int32 DestIndex = (Y * Width + X) * 4;
+                        DestData[DestIndex + 0] = (uint16)FMath::Clamp<int32>(FMath::RoundToInt(SrcRow[SrcIndex + 0] * 65535.f), 0, 65535);
+                        DestData[DestIndex + 1] = (uint16)FMath::Clamp<int32>(FMath::RoundToInt(SrcRow[SrcIndex + 1] * 65535.f), 0, 65535);
+                        DestData[DestIndex + 2] = (uint16)FMath::Clamp<int32>(FMath::RoundToInt(SrcRow[SrcIndex + 2] * 65535.f), 0, 65535);
+                        DestData[DestIndex + 3] = (uint16)FMath::Clamp<int32>(FMath::RoundToInt(SrcRow[SrcIndex + 3] * 65535.f), 0, 65535);
+                    }
+                }
+            }
+            else
+            {
+                uint8* DestData = Payload.GetData();
+                for (int32 Y = 0; Y < Height; ++Y)
+                {
+                    const float* SrcRow = reinterpret_cast<const float*>(SourceData + Y * RowPitch);
+                    for (int32 X = 0; X < Width; ++X)
+                    {
+                        const int32 SrcIndex = X * 4;
+                        const int32 DestIndex = (Y * Width + X) * 4;
+                        DestData[DestIndex + 0] = (uint8)FMath::Clamp<int32>(FMath::RoundToInt(SrcRow[SrcIndex + 0] * 255.f), 0, 255);
+                        DestData[DestIndex + 1] = (uint8)FMath::Clamp<int32>(FMath::RoundToInt(SrcRow[SrcIndex + 1] * 255.f), 0, 255);
+                        DestData[DestIndex + 2] = (uint8)FMath::Clamp<int32>(FMath::RoundToInt(SrcRow[SrcIndex + 2] * 255.f), 0, 255);
+                        DestData[DestIndex + 3] = (uint8)FMath::Clamp<int32>(FMath::RoundToInt(SrcRow[SrcIndex + 3] * 255.f), 0, 255);
+                    }
+                }
+            }
+
+            Readback->Unlock();
+            Readback.Reset();
+
+            return FPanoramaCaptureFrame(Resolution, TimeSeconds, FrameIndex, OutputFile, bUse16BitPNG, MoveTemp(Payload));
+        }
+
+        bool IsPreviewOnly() const
+        {
+            return bPreviewOnly;
+        }
+
+    private:
+        FCaptureOutputSettings Settings;
+        FIntPoint Resolution;
+        double TimeSeconds;
+        int32 FrameIndex;
+        FString OutputFile;
+        TUniquePtr<FRHIGPUTextureReadback> Readback;
+        bool bPreviewOnly;
+    };
+}
+
+#if WITH_PANORAMA_NVENC
+IMPLEMENT_GLOBAL_SHADER(FEncodeSurfaceCS, "/PanoramaCapture/Private/EncodeSurface.usf", "MainCS", SF_Compute);
+#endif
+
+UPanoramaCaptureController::UPanoramaCaptureController()
+    : bIsCapturing(false)
+    , CaptureStartSeconds(0.0)
+    , CaptureFrameCounter(0)
+    , CurrentStatus(TEXT("Idle"))
+    , LastStatusUpdateSeconds(0.0)
+    , AudioCaptureStartSeconds(0.0)
+{
+    PrimaryComponentTick.bCanEverTick = true;
+    PrimaryComponentTick.TickGroup = TG_PostUpdateWork;
+}
+
+void UPanoramaCaptureController::BeginPlay()
+{
+    Super::BeginPlay();
+    EnsureRig();
+    EnsureStatusDisplay();
+}
+
+void UPanoramaCaptureController::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    StopCapture();
+    Super::EndPlay(EndPlayReason);
+}
+
+void UPanoramaCaptureController::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+    Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+    if (bIsCapturing || PendingReadbacks.Num() > 0)
+    {
+        ConsumeFrameQueue();
+    }
+}
+
+void UPanoramaCaptureController::StartCapture()
+{
+    if (bIsCapturing)
+    {
+        return;
+    }
+
+    EnsureRig();
+    EnsureStatusDisplay();
+
+    if (!ManagedRig)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("Cannot start capture without a cubemap rig component."));
+        return;
+    }
+
+    FrameBuffer.Clear();
+    PendingReadbacks.Reset();
+    CapturedFrameFiles.Reset();
+    CapturedFrameTimes.Reset();
+    FirstVideoTimestamp.Reset();
+    LastVideoTimestamp.Reset();
+    AudioCaptureStartSeconds = 0.0;
+    RecordedAudioFile.Reset();
+    PendingWriteTasks.Reset();
+    ActiveElementaryStream.Reset();
+
+    InitializeOutputDirectory();
+    InitializeRingBuffer();
+
+    CaptureFrameCounter = 0;
+    LastStatusUpdateSeconds = GetWorld() ? GetWorld()->GetTimeSeconds() : 0.0;
+
+    CaptureStartSeconds = GetWorld() ? GetWorld()->GetTimeSeconds() : FPlatformTime::Seconds();
+
+#if WITH_PANORAMA_NVENC
+    if (OutputSettings.OutputPath == ECaptureOutputPath::NVENCVideo)
+    {
+        ActiveEncoder = FPanoramaCaptureModule::Get().CreateVideoEncoder();
+        if (!ActiveEncoder.IsValid())
+        {
+            UE_LOG(LogPanoramaCapture, Warning, TEXT("NVENC module not available. Falling back to PNG sequence output."));
+            OutputSettings.OutputPath = ECaptureOutputPath::PNGSequence;
+        }
+        else
+        {
+            const FIntPoint OutputResolution(OutputSettings.Resolution.Width, OutputSettings.Resolution.Height);
+            const FString ElementaryExtension = (OutputSettings.NVENC.Codec == ENVENCCodec::HEVC) ? TEXT("h265") : TEXT("h264");
+            ActiveElementaryStream = BuildVideoFilePath(ElementaryExtension);
+
+            FPanoramaVideoEncoderConfig EncoderConfig;
+            EncoderConfig.OutputSettings = OutputSettings;
+            EncoderConfig.OutputFile = BuildVideoFilePath(OutputSettings.ContainerFormat);
+            EncoderConfig.ElementaryStreamFile = ActiveElementaryStream;
+            EncoderConfig.OutputResolution = OutputResolution;
+            EncoderConfig.FrameRate = FMath::Max(1, OutputSettings.FrameRate);
+            EncoderConfig.bUseD3D12 = OutputSettings.bPreferD3D12Interop;
+            EncoderConfig.bUse10Bit = OutputSettings.NVENC.bUseP010;
+
+            if (!ActiveEncoder->Initialize(EncoderConfig))
+            {
+                UE_LOG(LogPanoramaCapture, Error, TEXT("Failed to initialize NVENC encoder. Falling back to PNG sequence output."));
+                ActiveElementaryStream.Reset();
+                ActiveEncoder.Reset();
+                OutputSettings.OutputPath = ECaptureOutputPath::PNGSequence;
+            }
+        }
+    }
+#else
+    if (OutputSettings.OutputPath == ECaptureOutputPath::NVENCVideo)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("NVENC output requested on unsupported platform. Using PNG sequence instead."));
+        OutputSettings.OutputPath = ECaptureOutputPath::PNGSequence;
+    }
+#endif
+
+    if (OutputSettings.bRecordAudio)
+    {
+        InitializeAudioCapture();
+    }
+
+    ManagedRig->OutputSettings = OutputSettings;
+    ManagedRig->bStereo = (OutputSettings.StereoMode != EPanoramaStereoMode::Mono);
+    ManagedRig->InitializeRig();
+
+    const float Interval = 1.0f / FMath::Max(1, OutputSettings.FrameRate);
+    bIsCapturing = true;
+    UpdateStatus(TEXT("Recording"));
+
+    GetWorld()->GetTimerManager().SetTimer(CaptureTimerHandle, this, &UPanoramaCaptureController::CaptureFrame, Interval, true);
+}
+
+void UPanoramaCaptureController::StopCapture()
+{
+    if (!bIsCapturing)
+    {
+        return;
+    }
+
+    bIsCapturing = false;
+    GetWorld()->GetTimerManager().ClearTimer(CaptureTimerHandle);
+
+    ShutdownAudioCapture();
+
+    FlushRenderingCommands();
+
+    const double WaitStart = FPlatformTime::Seconds();
+    while (PendingReadbacks.Num() > 0)
+    {
+        ProcessPendingReadbacks();
+        ConsumeFrameQueue();
+
+        if (PendingReadbacks.Num() == 0)
+        {
+            break;
+        }
+
+        if (FPlatformTime::Seconds() - WaitStart > 5.0)
+        {
+            UE_LOG(LogPanoramaCapture, Warning, TEXT("Timed out waiting for GPU readbacks during capture shutdown."));
+            break;
+        }
+
+        FPlatformProcess::Sleep(0.001f);
+    }
+
+    ConsumeFrameQueue();
+
+    if (ActiveEncoder.IsValid())
+    {
+        ActiveEncoder->Flush();
+        FString ElementaryStreamPath;
+        if (ActiveEncoder->FinalizeEncoding(ElementaryStreamPath))
+        {
+            ActiveElementaryStream = ElementaryStreamPath;
+        }
+        ActiveEncoder.Reset();
+    }
+
+    FinalizeCaptureOutputs();
+
+    PendingReadbacks.Reset();
+
+    UpdateStatus(TEXT("Idle"));
+}
+
+void UPanoramaCaptureController::EnsureRig()
+{
+    if (ManagedRig)
+    {
+        return;
+    }
+
+    if (AActor* OwnerActor = GetOwner())
+    {
+        ManagedRig = OwnerActor->FindComponentByClass<UCubemapCaptureRigComponent>();
+        if (!ManagedRig)
+        {
+            ManagedRig = NewObject<UCubemapCaptureRigComponent>(OwnerActor, TEXT("PanoramaCaptureRig"));
+            ManagedRig->RegisterComponent();
+        }
+    }
+
+    if (ManagedRig)
+    {
+        ManagedRig->OutputSettings = OutputSettings;
+        ManagedRig->bStereo = (OutputSettings.StereoMode != EPanoramaStereoMode::Mono);
+    }
+}
+
+void UPanoramaCaptureController::EnsureStatusDisplay()
+{
+    if (StatusBillboard || !GetOwner())
+    {
+        return;
+    }
+
+    StatusBillboard = NewObject<UTextRenderComponent>(GetOwner(), TEXT("PanoramaCaptureStatus"));
+    if (!StatusBillboard)
+    {
+        return;
+    }
+
+    if (USceneComponent* Root = GetOwner()->GetRootComponent())
+    {
+        StatusBillboard->SetupAttachment(Root);
+    }
+
+    StatusBillboard->RegisterComponent();
+    StatusBillboard->SetHorizontalAlignment(EHTA_Center);
+    StatusBillboard->SetVerticalAlignment(EVRTA_TextCenter);
+    StatusBillboard->SetWorldSize(48.f);
+    StatusBillboard->SetRelativeLocation(FVector(0.f, 0.f, 120.f));
+    StatusBillboard->SetTextRenderColor(FColor::White);
+    StatusBillboard->SetText(FText::FromString(TEXT("Idle")));
+}
+
+void UPanoramaCaptureController::CaptureFrame()
+{
+    if (!ManagedRig)
+    {
+        return;
+    }
+
+    ManagedRig->TickRig(0.0f);
+
+    const double Now = GetWorld()->GetTimeSeconds() - CaptureStartSeconds;
+    const FIntPoint OutputResolution(OutputSettings.Resolution.Width, OutputSettings.Resolution.Height);
+    const bool bStereo = (OutputSettings.StereoMode != EPanoramaStereoMode::Mono);
+    const bool bOverUnder = (OutputSettings.StereoMode == EPanoramaStereoMode::StereoOverUnder);
+    const bool bLinearGamma = (OutputSettings.GammaSpace == EPanoramaGammaSpace::Linear);
+
+    const bool bNeedsReadback = (OutputSettings.OutputPath == ECaptureOutputPath::PNGSequence) || OutputSettings.bEnablePreview;
+    FString FrameOutputFile;
+    TSharedPtr<FPendingCapturePayload, ESPMode::ThreadSafe> PendingPayload;
+    if (bNeedsReadback)
+    {
+        FCaptureOutputSettings PayloadSettings = OutputSettings;
+        bool bPreviewOnly = false;
+
+        if (OutputSettings.OutputPath == ECaptureOutputPath::PNGSequence)
+        {
+            FrameOutputFile = BuildFrameFilePath(CaptureFrameCounter);
+        }
+        else
+        {
+            bPreviewOnly = true;
+            PayloadSettings.bUse16BitPNG = false;
+        }
+
+        PendingPayload = MakeShared<FPendingCapturePayload, ESPMode::ThreadSafe>(PayloadSettings, OutputResolution, Now, CaptureFrameCounter, FrameOutputFile, bPreviewOnly);
+        PendingReadbacks.Add(PendingPayload);
+    }
+
+    if (!FirstVideoTimestamp.IsSet())
+    {
+        FirstVideoTimestamp = Now;
+    }
+    LastVideoTimestamp = Now;
+    ++CaptureFrameCounter;
+
+    const int32 EyeCount = bStereo ? 2 : 1;
+    TArray<FTextureRenderTargetResource*, TInlineAllocator<FacesPerEye * 2>> FaceResources;
+    FaceResources.Reserve(EyeCount * FacesPerEye);
+
+    for (int32 EyeIndex = 0; EyeIndex < EyeCount; ++EyeIndex)
+    {
+        const bool bLeftEye = (EyeIndex == 0);
+        for (int32 FaceIndex = 0; FaceIndex < FacesPerEye; ++FaceIndex)
+        {
+            if (UTextureRenderTarget2D* Target = ManagedRig->GetFaceRenderTarget(FaceIndex, bLeftEye))
+            {
+                if (FTextureRenderTargetResource* Resource = Target->GameThread_GetRenderTargetResource())
+                {
+                    FaceResources.Add(Resource);
+                }
+            }
+        }
+    }
+
+    if (FaceResources.Num() == 0)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("No cubemap faces available for capture."));
+        return;
+    }
+
+    const FCaptureOutputSettings LocalSettings = OutputSettings;
+    TWeakPtr<IPanoramaVideoEncoder, ESPMode::ThreadSafe> EncoderWeak = ActiveEncoder;
+
+    ENQUEUE_RENDER_COMMAND(PanoramaCaptureSubmit)(
+        [FaceResources, PendingPayload, OutputResolution, bStereo, bOverUnder, bLinearGamma, LocalSettings, EncoderWeak, Now](FRHICommandListImmediate& RHICmdList)
+        {
+            FRDGBuilder GraphBuilder(RHICmdList);
+
+            TArray<FRDGTextureRef, TInlineAllocator<FacesPerEye * 2>> RegisteredFaces;
+            RegisteredFaces.Reserve(FaceResources.Num());
+
+            for (int32 Index = 0; Index < FaceResources.Num(); ++Index)
+            {
+                if (FTextureRenderTargetResource* Resource = FaceResources[Index])
+                {
+                    const FTextureRHIRef TextureRHI = Resource->GetRenderTargetTexture();
+                    if (TextureRHI.IsValid())
+                    {
+                        const FString DebugName = FString::Printf(TEXT("PanoramaFace_%d"), Index);
+                        FRDGTextureRef Registered = GraphBuilder.RegisterExternalTexture(CreateRenderTarget(TextureRHI, *DebugName));
+                        RegisteredFaces.Add(Registered);
+                    }
+                }
+            }
+
+            if (RegisteredFaces.Num() == 0)
+            {
+                return;
+            }
+
+            const FIntPoint FaceSize(FaceResources[0]->GetSizeX(), FaceResources[0]->GetSizeY());
+            const EPixelFormat FaceFormat = FaceResources[0]->GetTextureRHI()->GetFormat();
+
+            FRDGTextureDesc CubeDesc = FRDGTextureDesc::CreateCube(FaceSize.X, FaceFormat, FClearValueBinding::Transparent, TexCreate_ShaderResource | TexCreate_UAV);
+            FRDGTextureRef LeftCube = GraphBuilder.CreateTexture(CubeDesc, TEXT("PanoramaCubeLeft"));
+            FRDGTextureRef RightCube = bStereo ? GraphBuilder.CreateTexture(CubeDesc, TEXT("PanoramaCubeRight")) : LeftCube;
+
+            for (int32 FaceIndex = 0; FaceIndex < FacesPerEye && FaceIndex < RegisteredFaces.Num(); ++FaceIndex)
+            {
+                FRHICopyTextureInfo CopyInfo;
+                CopyInfo.DestSliceIndex = FaceIndex;
+                AddCopyTexturePass(GraphBuilder, RegisteredFaces[FaceIndex], LeftCube, CopyInfo);
+            }
+
+            if (bStereo)
+            {
+                for (int32 FaceIndex = 0; FaceIndex < FacesPerEye; ++FaceIndex)
+                {
+                    const int32 SourceIndex = FaceIndex + FacesPerEye;
+                    if (RegisteredFaces.IsValidIndex(SourceIndex))
+                    {
+                        FRHICopyTextureInfo CopyInfo;
+                        CopyInfo.DestSliceIndex = FaceIndex;
+                        AddCopyTexturePass(GraphBuilder, RegisteredFaces[SourceIndex], RightCube, CopyInfo);
+                    }
+                }
+            }
+
+            FRDGTextureDesc OutputDesc = FRDGTextureDesc::Create2D(OutputResolution.X, OutputResolution.Y, PF_FloatRGBA, FClearValueBinding::Transparent, TexCreate_ShaderResource | TexCreate_UAV);
+            FRDGTextureRef OutputTexture = GraphBuilder.CreateTexture(OutputDesc, TEXT("PanoramaEquirect"));
+
+            FCubemapEquirectDispatchParams DispatchParams;
+            DispatchParams.SourceCubemapLeft = LeftCube;
+            DispatchParams.SourceCubemapRight = RightCube;
+            DispatchParams.DestinationEquirect = OutputTexture;
+            DispatchParams.OutputResolution = OutputResolution;
+            DispatchParams.bStereo = bStereo;
+            DispatchParams.bLinearGamma = bLinearGamma;
+            DispatchParams.bStereoOverUnder = bOverUnder;
+
+            FCubemapEquirectPass::AddComputePass(GraphBuilder, DispatchParams);
+
+            const bool bEncodeNVENC =
+#if WITH_PANORAMA_NVENC
+                (LocalSettings.OutputPath == ECaptureOutputPath::NVENCVideo);
+#else
+                false;
+#endif
+            FRDGTextureRef NVENCEncodeTexture = nullptr;
+
+#if WITH_PANORAMA_NVENC
+            if (bEncodeNVENC)
+            {
+                const EPixelFormat EncodeFormat = LocalSettings.NVENC.bUseP010 ? PF_A2B10G10R10 : PF_B8G8R8A8;
+                FRDGTextureDesc EncodeDesc = FRDGTextureDesc::Create2D(OutputResolution.X, OutputResolution.Y, EncodeFormat, FClearValueBinding::Transparent, TexCreate_ShaderResource | TexCreate_UAV);
+                NVENCEncodeTexture = GraphBuilder.CreateTexture(EncodeDesc, TEXT("PanoramaNVENCEncode"));
+
+                FEncodeSurfaceCS::FParameters* EncodeParameters = GraphBuilder.AllocParameters<FEncodeSurfaceCS::FParameters>();
+                EncodeParameters->SourceTexture = OutputTexture;
+                EncodeParameters->OutputTexture = GraphBuilder.CreateUAV(NVENCEncodeTexture);
+                EncodeParameters->bApplySRGB = bLinearGamma ? 1u : 0u;
+
+                TShaderMapRef<FEncodeSurfaceCS> EncodeShader(GetGlobalShaderMap(GMaxRHIFeatureLevel));
+                const FIntVector EncodeGroupCount(
+                    FMath::DivideAndRoundUp(OutputResolution.X, 8),
+                    FMath::DivideAndRoundUp(OutputResolution.Y, 8),
+                    1);
+
+                FComputeShaderUtils::AddPass(GraphBuilder, RDG_EVENT_NAME("Panorama::EncodeSurface"), EncodeShader, EncodeParameters, EncodeGroupCount);
+            }
+#endif // WITH_PANORAMA_NVENC
+
+            if (PendingPayload.IsValid())
+            {
+                if (FRHIGPUTextureReadback* Readback = PendingPayload->GetReadback())
+                {
+                    AddEnqueueCopyPass(GraphBuilder, Readback, OutputTexture, FIntRect(0, 0, OutputResolution.X, OutputResolution.Y));
+                }
+            }
+
+            TRefCountPtr<IPooledRenderTarget> ExtractedTexture;
+            GraphBuilder.QueueTextureExtraction(OutputTexture, &ExtractedTexture);
+
+            TRefCountPtr<IPooledRenderTarget> ExtractedNVENCTexture;
+            if (NVENCEncodeTexture)
+            {
+                GraphBuilder.QueueTextureExtraction(NVENCEncodeTexture, &ExtractedNVENCTexture);
+            }
+
+            GraphBuilder.Execute();
+
+#if WITH_PANORAMA_NVENC
+            if (bEncodeNVENC)
+            {
+                if (TSharedPtr<IPanoramaVideoEncoder> Encoder = EncoderWeak.Pin())
+                {
+                    if (ExtractedNVENCTexture.IsValid())
+                    {
+                        FPanoramaVideoEncoderFrame EncoderFrame;
+                        EncoderFrame.RgbaTexture = ExtractedNVENCTexture->GetRHI();
+                        EncoderFrame.TimeSeconds = Now;
+                        Encoder->EncodeFrame(EncoderFrame);
+                    }
+                }
+            }
+#endif
+        });
+}
+
+void UPanoramaCaptureController::ConsumeFrameQueue()
+{
+    ProcessPendingReadbacks();
+
+    FPanoramaCaptureFrame Frame;
+    while (FrameBuffer.Dequeue(Frame))
+    {
+        if (OutputSettings.OutputPath == ECaptureOutputPath::PNGSequence)
+        {
+            WritePNGFrame(MoveTemp(Frame));
+        }
+    }
+}
+
+void UPanoramaCaptureController::ProcessPendingReadbacks()
+{
+    for (int32 Index = PendingReadbacks.Num() - 1; Index >= 0; --Index)
+    {
+        const TSharedPtr<FPendingCapturePayload, ESPMode::ThreadSafe>& Pending = PendingReadbacks[Index];
+        if (Pending.IsValid() && Pending->IsReady())
+        {
+            const bool bPreviewOnly = Pending->IsPreviewOnly();
+            FPanoramaCaptureFrame ResolvedFrame = Pending->Resolve();
+
+            if (OutputSettings.bEnablePreview)
+            {
+                UpdatePreviewFromFrame(ResolvedFrame);
+            }
+
+            if (!bPreviewOnly)
+            {
+                if (!FrameBuffer.Enqueue(MoveTemp(ResolvedFrame)))
+                {
+                    UpdateStatus(TEXT("Dropped"));
+                }
+                else if (bIsCapturing)
+                {
+                    UpdateStatus(TEXT("Recording"));
+                }
+            }
+            PendingReadbacks.RemoveAtSwap(Index);
+        }
+    }
+}
+
+void UPanoramaCaptureController::WritePNGFrame(FPanoramaCaptureFrame&& Frame)
+{
+    const FString OutputFile = Frame.OutputFile;
+    CapturedFrameFiles.Add(OutputFile);
+    const double FrameTimeSeconds = Frame.TimeSeconds;
+
+    const bool bUse16BitPNG = Frame.bIs16Bit;
+    const FIntPoint Resolution = Frame.Resolution;
+
+    TArray<uint8> Payload = MoveTemp(Frame.Payload);
+
+    TFuture<void> WriteTask = Async(EAsyncExecution::ThreadPool,
+        [Payload = MoveTemp(Payload), Resolution, OutputFile, bUse16BitPNG]()
+        {
+            if (Payload.Num() == 0)
+            {
+                return;
+            }
+
+            IImageWrapperModule& ImageWrapperModule = FModuleManager::LoadModuleChecked<IImageWrapperModule>(TEXT("ImageWrapper"));
+            TSharedPtr<IImageWrapper> Wrapper = ImageWrapperModule.CreateImageWrapper(EImageFormat::PNG);
+            const ERGBFormat RGBFormat = ERGBFormat::RGBA;
+            const int32 BitDepth = bUse16BitPNG ? 16 : 8;
+
+            if (Wrapper->SetRaw(Payload.GetData(), Payload.Num(), Resolution.X, Resolution.Y, RGBFormat, BitDepth))
+            {
+                const TArray64<uint8>& Compressed = Wrapper->GetCompressed(0);
+                FFileHelper::SaveArrayToFile(Compressed, *OutputFile);
+            }
+        });
+    PendingWriteTasks.Add(MoveTemp(WriteTask));
+    CapturedFrameTimes.Add(FrameTimeSeconds);
+}
+
+void UPanoramaCaptureController::UpdatePreviewFromFrame(const FPanoramaCaptureFrame& Frame)
+{
+    if (!OutputSettings.bEnablePreview)
+    {
+        return;
+    }
+
+    const int32 SourceWidth = Frame.Resolution.X;
+    const int32 SourceHeight = Frame.Resolution.Y;
+    const float PreviewScale = FMath::Clamp(OutputSettings.PreviewScale, 0.1f, 1.0f);
+    const int32 PreviewWidth = FMath::Max(1, FMath::RoundToInt(SourceWidth * PreviewScale));
+    const int32 PreviewHeight = FMath::Max(1, FMath::RoundToInt(SourceHeight * PreviewScale));
+
+    TArray<uint8> PreviewPixels;
+    PreviewPixels.SetNumUninitialized(PreviewWidth * PreviewHeight * 4);
+
+    const float StepX = static_cast<float>(SourceWidth) / static_cast<float>(PreviewWidth);
+    const float StepY = static_cast<float>(SourceHeight) / static_cast<float>(PreviewHeight);
+
+    if (Frame.bIs16Bit)
+    {
+        const uint16* SourceData = reinterpret_cast<const uint16*>(Frame.Payload.GetData());
+        for (int32 Y = 0; Y < PreviewHeight; ++Y)
+        {
+            const int32 SrcY = FMath::Clamp(static_cast<int32>(Y * StepY), 0, SourceHeight - 1);
+            for (int32 X = 0; X < PreviewWidth; ++X)
+            {
+                const int32 SrcX = FMath::Clamp(static_cast<int32>(X * StepX), 0, SourceWidth - 1);
+                const int32 SrcIndex = (SrcY * SourceWidth + SrcX) * 4;
+                const int32 DstIndex = (Y * PreviewWidth + X) * 4;
+                PreviewPixels[DstIndex + 0] = static_cast<uint8>(SourceData[SrcIndex + 2] >> 8);
+                PreviewPixels[DstIndex + 1] = static_cast<uint8>(SourceData[SrcIndex + 1] >> 8);
+                PreviewPixels[DstIndex + 2] = static_cast<uint8>(SourceData[SrcIndex + 0] >> 8);
+                PreviewPixels[DstIndex + 3] = static_cast<uint8>(SourceData[SrcIndex + 3] >> 8);
+            }
+        }
+    }
+    else
+    {
+        const uint8* SourceData = Frame.Payload.GetData();
+        for (int32 Y = 0; Y < PreviewHeight; ++Y)
+        {
+            const int32 SrcY = FMath::Clamp(static_cast<int32>(Y * StepY), 0, SourceHeight - 1);
+            for (int32 X = 0; X < PreviewWidth; ++X)
+            {
+                const int32 SrcX = FMath::Clamp(static_cast<int32>(X * StepX), 0, SourceWidth - 1);
+                const int32 SrcIndex = (SrcY * SourceWidth + SrcX) * 4;
+                const int32 DstIndex = (Y * PreviewWidth + X) * 4;
+                PreviewPixels[DstIndex + 0] = SourceData[SrcIndex + 2];
+                PreviewPixels[DstIndex + 1] = SourceData[SrcIndex + 1];
+                PreviewPixels[DstIndex + 2] = SourceData[SrcIndex + 0];
+                PreviewPixels[DstIndex + 3] = SourceData[SrcIndex + 3];
+            }
+        }
+    }
+
+    if (!PreviewTexture || PreviewTexture->GetSizeX() != PreviewWidth || PreviewTexture->GetSizeY() != PreviewHeight)
+    {
+        PreviewTexture = UTexture2D::CreateTransient(PreviewWidth, PreviewHeight, PF_B8G8R8A8);
+        PreviewTexture->SRGB = true;
+    }
+
+    if (PreviewTexture && PreviewTexture->GetPlatformData() && PreviewTexture->GetPlatformData()->Mips.Num() > 0)
+    {
+        FTexture2DMipMap& Mip = PreviewTexture->GetPlatformData()->Mips[0];
+        void* TextureData = Mip.BulkData.Lock(LOCK_READ_WRITE);
+        FMemory::Memcpy(TextureData, PreviewPixels.GetData(), PreviewPixels.Num());
+        Mip.BulkData.Unlock();
+        PreviewTexture->UpdateResource();
+    }
+}
+
+void UPanoramaCaptureController::UpdateStatus(FName NewStatus)
+{
+    const double NowSeconds = GetWorld() ? GetWorld()->GetTimeSeconds() : FPlatformTime::Seconds();
+    FString StatusLabel = NewStatus.ToString();
+
+    const int32 QueueCount = FrameBuffer.Num();
+    const int32 DroppedCount = FrameBuffer.GetDroppedFrames();
+    const int32 BlockedCount = FrameBuffer.GetBlockedFrames();
+
+    StatusLabel += FString::Printf(TEXT("|Q:%d"), QueueCount);
+
+    if (DroppedCount > 0)
+    {
+        StatusLabel += FString::Printf(TEXT("|Drop:%d"), DroppedCount);
+    }
+
+    if (BlockedCount > 0)
+    {
+        StatusLabel += FString::Printf(TEXT("|Block:%d"), BlockedCount);
+    }
+
+    if (ActiveEncoder.IsValid())
+    {
+        const FPanoramaVideoEncoderStats EncoderStats = ActiveEncoder->GetStats();
+        if (EncoderStats.QueuedFrames > 0)
+        {
+            StatusLabel += FString::Printf(TEXT("|EncQ:%d"), EncoderStats.QueuedFrames);
+        }
+        if (EncoderStats.DroppedFrames > 0)
+        {
+            StatusLabel += FString::Printf(TEXT("|EncDrop:%d"), EncoderStats.DroppedFrames);
+        }
+    }
+
+    const FName EnrichedStatus(*StatusLabel);
+
+    const bool bStatusChanged = (CurrentStatus != EnrichedStatus);
+    const bool bTimeElapsed = (NowSeconds - LastStatusUpdateSeconds) > 0.5;
+
+    if (bStatusChanged || bTimeElapsed)
+    {
+        CurrentStatus = EnrichedStatus;
+        LastStatusUpdateSeconds = NowSeconds;
+        OnStatusChanged.Broadcast(EnrichedStatus);
+
+        UE_LOG(LogPanoramaCapture, Log, TEXT("Capture status updated: %s"), *StatusLabel);
+    }
+
+    if (StatusBillboard)
+    {
+        StatusBillboard->SetText(FText::FromString(StatusLabel));
+
+        FColor StatusColor = FColor::White;
+        if (NewStatus == TEXT("Recording"))
+        {
+            StatusColor = FColor::Green;
+        }
+        else if (NewStatus == TEXT("Dropped"))
+        {
+            StatusColor = FColor::Orange;
+        }
+        else if (NewStatus == TEXT("Idle"))
+        {
+            StatusColor = FColor::Silver;
+        }
+        StatusBillboard->SetTextRenderColor(StatusColor);
+    }
+}
+
+void UPanoramaCaptureController::InitializeRingBuffer()
+{
+    int32 TargetCapacity = OutputSettings.RingBufferCapacityOverride;
+
+    if (!OutputSettings.bUseRingBuffer)
+    {
+        TargetCapacity = 1;
+    }
+    else if (TargetCapacity <= 0)
+    {
+        const float Duration = FMath::Max(0.1f, OutputSettings.RingBufferDurationSeconds);
+        TargetCapacity = FMath::Max(1, FMath::RoundToInt(OutputSettings.FrameRate * Duration));
+    }
+
+    FrameBuffer.Initialize(TargetCapacity, OutputSettings.RingBufferPolicy);
+}
+
+void UPanoramaCaptureController::InitializeOutputDirectory()
+{
+    const UPanoramaCaptureSettings* Settings = GetDefault<UPanoramaCaptureSettings>();
+
+    FString DirectorySetting = OutputSettings.OutputDirectory;
+    if (DirectorySetting.IsEmpty())
+    {
+        DirectorySetting = Settings->DefaultOutputDirectory;
+    }
+
+    FString RootDirectory;
+    if (!DirectorySetting.IsEmpty() && !FPaths::IsRelative(DirectorySetting))
+    {
+        RootDirectory = DirectorySetting;
+    }
+    else
+    {
+        const FString SanitizedDirectory = SanitizeFileComponent(DirectorySetting);
+        if (SanitizedDirectory.IsEmpty())
+        {
+            RootDirectory = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("PanoramaCapture"));
+        }
+        else
+        {
+            RootDirectory = FPaths::Combine(FPaths::ProjectSavedDir(), SanitizedDirectory);
+        }
+    }
+
+    ActiveBaseFileName = OutputSettings.BaseFileName.IsEmpty() ? TEXT("PanoramaCapture") : SanitizeFileComponent(OutputSettings.BaseFileName);
+
+    if (ActiveBaseFileName.IsEmpty())
+    {
+        ActiveBaseFileName = TEXT("PanoramaCapture");
+    }
+
+    const FString Timestamp = FDateTime::Now().ToString(TEXT("%Y%m%d_%H%M%S"));
+    ActiveCaptureDirectory = FPaths::Combine(RootDirectory, Timestamp);
+
+    IFileManager::Get().MakeDirectory(*ActiveCaptureDirectory, true);
+}
+
+void UPanoramaCaptureController::InitializeAudioCapture()
+{
+#if WITH_AUDIO_MIXER
+    const UPanoramaCaptureSettings* Settings = GetDefault<UPanoramaCaptureSettings>();
+    RecordedSubmix.Reset();
+
+    AudioCaptureStartSeconds = GetWorld() ? GetWorld()->GetTimeSeconds() : FPlatformTime::Seconds();
+
+    if (Settings->AudioSubmix != NAME_None)
+    {
+        RecordedSubmix = FindObject<USoundSubmixBase>(ANY_PACKAGE, *Settings->AudioSubmix.ToString());
+    }
+
+    if (RecordedSubmix.IsValid())
+    {
+        UAudioMixerBlueprintLibrary::StartRecordingOutput(this, 0.0f, RecordedSubmix.Get());
+        UE_LOG(LogPanoramaCapture, Log, TEXT("Recording audio from submix '%s'"), *RecordedSubmix->GetName());
+    }
+    else if (Settings->AudioSubmix != NAME_None)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("Audio submix '%s' not found. Audio will not be recorded."), *Settings->AudioSubmix.ToString());
+    }
+#else
+    UE_LOG(LogPanoramaCapture, Warning, TEXT("AudioMixer module is not enabled. Audio will not be recorded."));
+#endif
+}
+
+void UPanoramaCaptureController::ShutdownAudioCapture()
+{
+#if WITH_AUDIO_MIXER
+    if (!RecordedSubmix.IsValid())
+    {
+        return;
+    }
+
+    if (USoundWave* RecordedWave = UAudioMixerBlueprintLibrary::StopRecordingOutput(this, EAudioRecordingExportType::SoundWave, ActiveBaseFileName, RecordedSubmix.Get()))
+    {
+        const FString AudioPath = BuildVideoFilePath(TEXT("wav"));
+        UAudioMixerBlueprintLibrary::ExportToWavFile(RecordedWave, AudioPath);
+        RecordedAudioFile = AudioPath;
+        UE_LOG(LogPanoramaCapture, Log, TEXT("Wrote audio track to '%s'"), *AudioPath);
+    }
+
+    RecordedSubmix.Reset();
+#else
+    RecordedAudioFile.Reset();
+#endif
+}
+
+void UPanoramaCaptureController::FinalizeCaptureOutputs()
+{
+    for (TFuture<void>& Task : PendingWriteTasks)
+    {
+        Task.Wait();
+    }
+    PendingWriteTasks.Reset();
+
+    if (OutputSettings.OutputPath == ECaptureOutputPath::PNGSequence)
+    {
+        if (!OutputSettings.bAutoAssembleVideo)
+        {
+            return;
+        }
+
+        if (CapturedFrameFiles.Num() == 0)
+        {
+            UE_LOG(LogPanoramaCapture, Warning, TEXT("No PNG frames were written. Skipping video assembly."));
+            return;
+        }
+
+        const FString Extension = OutputSettings.ContainerFormat.IsEmpty() ? TEXT("mp4") : OutputSettings.ContainerFormat;
+        const FString OutputVideo = BuildVideoFilePath(Extension);
+
+        TStringBuilder<4096> ConcatBuilder;
+        ConcatBuilder.Append(TEXT("ffconcat version 1.0\n"));
+
+        const int32 FrameCount = CapturedFrameFiles.Num();
+        const int32 TimeCount = CapturedFrameTimes.Num();
+        const double DefaultDuration = 1.0 / static_cast<double>(FMath::Max(1, OutputSettings.FrameRate));
+
+        for (int32 Index = 0; Index < FrameCount; ++Index)
+        {
+            const FString AbsolutePath = FPaths::ConvertRelativePathToFull(CapturedFrameFiles[Index]);
+            ConcatBuilder.Appendf(TEXT("file '%s'\n"), *AbsolutePath);
+
+            if (Index < TimeCount - 1)
+            {
+                double Duration = CapturedFrameTimes[Index + 1] - CapturedFrameTimes[Index];
+                Duration = FMath::Max(Duration, DefaultDuration * 0.25);
+                ConcatBuilder.Appendf(TEXT("duration %.6f\n"), Duration);
+            }
+        }
+
+        if (FrameCount > 0)
+        {
+            const FString AbsolutePath = FPaths::ConvertRelativePathToFull(CapturedFrameFiles.Last());
+            ConcatBuilder.Appendf(TEXT("file '%s'\n"), *AbsolutePath);
+        }
+
+        const FString ConcatFile = FPaths::Combine(ActiveCaptureDirectory, TEXT("frames.ffconcat"));
+        if (!FFileHelper::SaveStringToFile(ConcatBuilder.ToString(), *ConcatFile))
+        {
+            UE_LOG(LogPanoramaCapture, Error, TEXT("Failed to write ffconcat manifest '%s'."), *ConcatFile);
+            return;
+        }
+
+        FString CommandInput = FString::Printf(TEXT("-safe 0 -f concat -i \"%s\""), *ConcatFile);
+
+        double AudioOffsetSeconds = 0.0;
+        if (!RecordedAudioFile.IsEmpty())
+        {
+            const double AudioStart = AudioCaptureStartSeconds - CaptureStartSeconds;
+            const double FirstFrame = CapturedFrameTimes.Num() > 0 ? CapturedFrameTimes[0] : (FirstVideoTimestamp.IsSet() ? FirstVideoTimestamp.GetValue() : 0.0);
+            AudioOffsetSeconds = FMath::Clamp(FirstFrame - AudioStart, -2.0, 2.0);
+        }
+
+        FString AudioFile = RecordedAudioFile;
+        if (!AssembleWithFFmpeg(CommandInput, AudioFile, OutputVideo, false, AudioOffsetSeconds))
+        {
+            UE_LOG(LogPanoramaCapture, Warning, TEXT("Failed to assemble PNG sequence with FFmpeg."));
+        }
+        return;
+    }
+
+    if (OutputSettings.OutputPath == ECaptureOutputPath::NVENCVideo)
+    {
+        FinalizeNVENCOutput();
+    }
+}
+
+void UPanoramaCaptureController::FinalizeNVENCOutput()
+{
+    if (!OutputSettings.bAutoMuxNVENC)
+    {
+        if (!ActiveElementaryStream.IsEmpty())
+        {
+            const FString Extension = OutputSettings.ContainerFormat.IsEmpty() ? TEXT("mp4") : OutputSettings.ContainerFormat;
+            const FString TargetPath = BuildVideoFilePath(Extension);
+            if (!TargetPath.Equals(ActiveElementaryStream, ESearchCase::CaseSensitive))
+            {
+                IFileManager::Get().Copy(*TargetPath, *ActiveElementaryStream);
+            }
+        }
+        return;
+    }
+
+    if (ActiveElementaryStream.IsEmpty() || !FPaths::FileExists(ActiveElementaryStream))
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("No NVENC elementary stream was produced. Skipping mux."));
+        return;
+    }
+
+    const FString Extension = OutputSettings.ContainerFormat.IsEmpty() ? TEXT("mp4") : OutputSettings.ContainerFormat;
+    const FString OutputVideo = BuildVideoFilePath(Extension);
+
+    FString VideoInput = FString::Printf(TEXT("-framerate %d -i \"%s\""), OutputSettings.FrameRate, *ActiveElementaryStream);
+
+    double AudioOffsetSeconds = 0.0;
+    if (!RecordedAudioFile.IsEmpty())
+    {
+        const double AudioStart = AudioCaptureStartSeconds - CaptureStartSeconds;
+        const double FirstFrame = FirstVideoTimestamp.IsSet() ? FirstVideoTimestamp.GetValue() : 0.0;
+        AudioOffsetSeconds = FMath::Clamp(FirstFrame - AudioStart, -2.0, 2.0);
+    }
+
+    if (!AssembleWithFFmpeg(VideoInput, RecordedAudioFile, OutputVideo, true, AudioOffsetSeconds))
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("Failed to mux NVENC stream. Leaving elementary stream at '%s'."), *ActiveElementaryStream);
+    }
+}
+
+bool UPanoramaCaptureController::AssembleWithFFmpeg(const FString& VideoInputArgs, const FString& AudioFile, const FString& OutputFile, bool bCopyVideoStream, double AudioOffsetSeconds)
+{
+    const UPanoramaCaptureSettings* Settings = GetDefault<UPanoramaCaptureSettings>();
+    if (!Settings || Settings->FFmpegExecutable.IsEmpty())
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("FFmpeg executable not configured. Skipping container assembly."));
+        return false;
+    }
+
+    if (!FPaths::FileExists(Settings->FFmpegExecutable))
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("FFmpeg executable not found at '%s'."), *Settings->FFmpegExecutable);
+        return false;
+    }
+
+    FString AudioArgs;
+    if (!AudioFile.IsEmpty() && FPaths::FileExists(AudioFile))
+    {
+        if (!FMath::IsNearlyZero(AudioOffsetSeconds))
+        {
+            AudioArgs = FString::Printf(TEXT(" -itsoffset %.6f -i \"%s\""), AudioOffsetSeconds, *AudioFile);
+        }
+        else
+        {
+            AudioArgs = FString::Printf(TEXT(" -i \"%s\""), *AudioFile);
+        }
+    }
+
+    FString VideoCodecArgs;
+    if (bCopyVideoStream)
+    {
+        VideoCodecArgs = TEXT(" -c:v copy");
+    }
+    else
+    {
+        const bool bUseHEVC = (OutputSettings.NVENC.Codec == ENVENCCodec::HEVC);
+        VideoCodecArgs = FString::Printf(TEXT(" -c:v %s"), bUseHEVC ? TEXT("libx265") : TEXT("libx264"));
+        if (!bUseHEVC)
+        {
+            VideoCodecArgs += TEXT(" -pix_fmt yuv420p");
+        }
+        VideoCodecArgs += TEXT(" -vsync vfr");
+    }
+
+    FString ExtraArgs = OutputSettings.FFmpegMuxOverride;
+    if (!ExtraArgs.IsEmpty())
+    {
+        ExtraArgs = TEXT(" ") + ExtraArgs;
+    }
+
+    const FString CommandLine = FString::Printf(TEXT("-y %s%s%s%s -shortest \"%s\""),
+        *VideoInputArgs,
+        *AudioArgs,
+        *VideoCodecArgs,
+        *ExtraArgs,
+        *OutputFile);
+
+    int32 ReturnCode = 0;
+    FString StdOut;
+    FString StdErr;
+    FPlatformProcess::ExecProcess(*Settings->FFmpegExecutable, *CommandLine, &ReturnCode, &StdOut, &StdErr);
+
+    if (ReturnCode != 0)
+    {
+        UE_LOG(LogPanoramaCapture, Warning, TEXT("FFmpeg failed with code %d. %s"), ReturnCode, *StdErr);
+        return false;
+    }
+
+    UE_LOG(LogPanoramaCapture, Log, TEXT("FFmpeg assembled output '%s'."), *OutputFile);
+    return true;
+}
+
+FString UPanoramaCaptureController::BuildFrameFilePath(int32 FrameIndex) const
+{
+    const FString FileName = FString::Printf(TEXT("%s_%05d.png"), *ActiveBaseFileName, FrameIndex);
+    return FPaths::Combine(ActiveCaptureDirectory, FileName);
+}
+
+FString UPanoramaCaptureController::BuildVideoFilePath(const FString& Extension) const
+{
+    FString CleanExtension = Extension;
+    if (CleanExtension.StartsWith(TEXT(".")))
+    {
+        CleanExtension.RightChopInline(1);
+    }
+    if (CleanExtension.IsEmpty())
+    {
+        CleanExtension = TEXT("mp4");
+    }
+
+    return FPaths::Combine(ActiveCaptureDirectory, FString::Printf(TEXT("%s.%s"), *ActiveBaseFileName, *CleanExtension));
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureModule.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Private/PanoramaCaptureModule.cpp
@@ -1,0 +1,72 @@
+#include "PanoramaCaptureModule.h"
+#include "CaptureOutputSettings.h"
+#include "CubemapCaptureRigComponent.h"
+#include "DeveloperSettingsModule.h"
+#include "Interfaces/IPluginManager.h"
+#include "Misc/Paths.h"
+#include "Modules/ModuleManager.h"
+#include "ShaderCore.h"
+
+DEFINE_LOG_CATEGORY(LogPanoramaCapture);
+
+IMPLEMENT_MODULE(FPanoramaCaptureModule, PanoramaCapture)
+
+void FPanoramaCaptureModule::StartupModule()
+{
+    if (TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("PanoramaCapture")))
+    {
+        const FString PluginShaderDir = FPaths::Combine(Plugin->GetBaseDir(), TEXT("Shaders"));
+        AddShaderSourceDirectoryMapping(TEXT("/PanoramaCapture"), PluginShaderDir);
+        bShaderDirectoryRegistered = true;
+    }
+
+    RegisterSettings();
+}
+
+void FPanoramaCaptureModule::ShutdownModule()
+{
+    if (bShaderDirectoryRegistered)
+    {
+        RemoveShaderSourceDirectoryMapping(TEXT("/PanoramaCapture"));
+        bShaderDirectoryRegistered = false;
+    }
+    UnregisterSettings();
+}
+
+void FPanoramaCaptureModule::RegisterSettings()
+{
+#if WITH_EDITOR
+    if (ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings"))
+    {
+        SettingsModule->RegisterSettings("Project", "Plugins", "PanoramaCapture",
+            NSLOCTEXT("PanoramaCapture", "SettingsName", "Panorama Capture"),
+            NSLOCTEXT("PanoramaCapture", "SettingsDescription", "Configure cubemap and equirectangular capture defaults."),
+            GetMutableDefault<UPanoramaCaptureSettings>());
+    }
+#endif
+}
+
+void FPanoramaCaptureModule::UnregisterSettings()
+{
+#if WITH_EDITOR
+    if (ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings"))
+    {
+        SettingsModule->UnregisterSettings("Project", "Plugins", "PanoramaCapture");
+    }
+#endif
+}
+
+void FPanoramaCaptureModule::RegisterVideoEncoderFactory(TFunction<TSharedPtr<IPanoramaVideoEncoder>()> InFactory)
+{
+    EncoderFactory = MoveTemp(InFactory);
+}
+
+void FPanoramaCaptureModule::UnregisterVideoEncoderFactory()
+{
+    EncoderFactory = nullptr;
+}
+
+TSharedPtr<IPanoramaVideoEncoder> FPanoramaCaptureModule::CreateVideoEncoder() const
+{
+    return EncoderFactory ? EncoderFactory() : nullptr;
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/CaptureFrameQueue.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/CaptureFrameQueue.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "CaptureOutputSettings.h"
+
+struct FPanoramaCaptureFrame
+{
+    FPanoramaCaptureFrame() = default;
+
+    FPanoramaCaptureFrame(const FIntPoint InResolution, const double InTimeSeconds, const int32 InFrameIndex, const FString& InOutputFile, bool bInIs16Bit, TArray<uint8>&& InPayload)
+        : Resolution(InResolution)
+        , TimeSeconds(InTimeSeconds)
+        , FrameIndex(InFrameIndex)
+        , OutputFile(InOutputFile)
+        , bIs16Bit(bInIs16Bit)
+        , Payload(MoveTemp(InPayload))
+    {
+    }
+
+    FIntPoint Resolution = FIntPoint::ZeroValue;
+    double TimeSeconds = 0.0;
+    int32 FrameIndex = 0;
+    FString OutputFile;
+    bool bIs16Bit = false;
+    TArray<uint8> Payload;
+};
+
+class PANORAMACAPTURE_API FCaptureFrameRingBuffer
+{
+public:
+    FCaptureFrameRingBuffer();
+    ~FCaptureFrameRingBuffer();
+
+    void Initialize(int32 InCapacity, ERingBufferOverflowPolicy InPolicy);
+    void Clear();
+
+    bool Enqueue(FPanoramaCaptureFrame&& Frame);
+    bool Dequeue(FPanoramaCaptureFrame& OutFrame);
+
+    int32 Num() const;
+    int32 Capacity() const;
+
+    int32 GetDroppedFrames() const;
+    int32 GetBlockedFrames() const;
+    ERingBufferOverflowPolicy GetOverflowPolicy() const { return OverflowPolicy; }
+
+private:
+    mutable FCriticalSection CriticalSection;
+    TArray<FPanoramaCaptureFrame> Frames;
+    int32 Head;
+    int32 Tail;
+    int32 CurrentSize;
+    int32 MaxCapacity;
+    int32 DroppedFrames;
+    int32 BlockedEnqueues;
+    ERingBufferOverflowPolicy OverflowPolicy;
+    FEvent* NotEmptyEvent;
+    FEvent* NotFullEvent;
+};

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/CaptureOutputSettings.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/CaptureOutputSettings.h
@@ -1,0 +1,264 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DeveloperSettings.h"
+#include "CaptureOutputSettings.generated.h"
+
+UENUM(BlueprintType)
+enum class EPanoramaStereoMode : uint8
+{
+    Mono,
+    StereoOverUnder,
+    StereoSideBySide
+};
+
+UENUM(BlueprintType)
+enum class ECaptureOutputPath : uint8
+{
+    PNGSequence,
+    NVENCVideo
+};
+
+UENUM(BlueprintType)
+enum class EEquiLayout : uint8
+{
+    Full360,
+    UpperHemisphere,
+    LowerHemisphere
+};
+
+UENUM(BlueprintType)
+enum class EPanoramaGammaSpace : uint8
+{
+    sRGB,
+    Linear
+};
+
+UENUM(BlueprintType)
+enum class ERingBufferOverflowPolicy : uint8
+{
+    DropOldest,
+    DropNewest,
+    BlockUntilAvailable
+};
+
+UENUM(BlueprintType)
+enum class ENVENCCodec : uint8
+{
+    H264,
+    HEVC
+};
+
+UENUM(BlueprintType)
+enum class ENVENCRateControlMode : uint8
+{
+    CBR,
+    VBR,
+    CQP
+};
+
+USTRUCT(BlueprintType)
+struct FNVENCRateControl
+{
+    GENERATED_BODY()
+
+    FNVENCRateControl()
+        : Codec(ENVENCCodec::HEVC)
+        , RateControlMode(ENVENCRateControlMode::CBR)
+        , BitrateMbps(80.f)
+        , MaxBitrateMbps(120.f)
+        , GOPLength(30)
+        , bEnableBFrames(true)
+        , BFrameCount(2)
+        , bUseP010(false)
+        , bZeroLatency(false)
+        , bAsyncTransfer(true)
+        , AsyncDepth(4)
+        , VBVMultiplier(1.0f)
+    {
+    }
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "NVENC")
+    ENVENCCodec Codec;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "NVENC")
+    ENVENCRateControlMode RateControlMode;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "NVENC", meta = (ClampMin = "1"))
+    float BitrateMbps;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "NVENC", meta = (ClampMin = "0"))
+    float MaxBitrateMbps;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "NVENC", meta = (ClampMin = "1"))
+    int32 GOPLength;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "NVENC")
+    bool bEnableBFrames;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "NVENC", meta = (EditCondition = "bEnableBFrames", ClampMin = "0"))
+    int32 BFrameCount;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "NVENC", meta = (ToolTip = "Encode using 10-bit P010 surfaces"))
+    bool bUseP010;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "NVENC", meta = (ToolTip = "Disables lookahead for lowest latency"))
+    bool bZeroLatency;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "NVENC", meta = (ToolTip = "Encode on a worker thread"))
+    bool bAsyncTransfer;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "NVENC", meta = (ClampMin = "1"))
+    int32 AsyncDepth;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "NVENC", meta = (ClampMin = "0.1"))
+    float VBVMultiplier;
+};
+
+USTRUCT(BlueprintType)
+struct FPanoramaCaptureResolution
+{
+    GENERATED_BODY()
+
+    FPanoramaCaptureResolution()
+        : Width(3840)
+        , Height(2160)
+    {
+    }
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    int32 Width;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    int32 Height;
+};
+
+USTRUCT(BlueprintType)
+struct FCaptureOutputSettings
+{
+    GENERATED_BODY()
+
+    FCaptureOutputSettings()
+        : OutputPath(ECaptureOutputPath::PNGSequence)
+        , StereoMode(EPanoramaStereoMode::Mono)
+        , OutputLayout(EEquiLayout::Full360)
+        , GammaSpace(EPanoramaGammaSpace::sRGB)
+        , FrameRate(30)
+        , bEmbedTimecode(true)
+        , bRecordAudio(true)
+        , bEnablePreview(true)
+        , PreviewScale(0.25f)
+        , bUseRingBuffer(true)
+        , RingBufferPolicy(ERingBufferOverflowPolicy::DropOldest)
+        , RingBufferDurationSeconds(4.f)
+        , RingBufferCapacityOverride(0)
+        , OutputDirectory(TEXT(""))
+        , BaseFileName(TEXT("PanoramaCapture"))
+        , ContainerFormat(TEXT("mp4"))
+        , bAutoAssembleVideo(true)
+        , bAutoMuxNVENC(true)
+        , bPreferD3D12Interop(true)
+        , MaxEncoderLatencyMs(120.0f)
+        , FFmpegMuxOverride(TEXT(""))
+    {
+    }
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    ECaptureOutputPath OutputPath;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    EPanoramaStereoMode StereoMode;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    EEquiLayout OutputLayout;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    EPanoramaGammaSpace GammaSpace;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    FPanoramaCaptureResolution Resolution;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    int32 FrameRate;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    bool bEmbedTimecode;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture|Audio")
+    bool bRecordAudio;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    bool bEnablePreview;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture", meta = (EditCondition = "bEnablePreview", ClampMin = "0.1", ClampMax = "1.0"))
+    float PreviewScale;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    bool bUseRingBuffer;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture", meta = (EditCondition = "bUseRingBuffer"))
+    ERingBufferOverflowPolicy RingBufferPolicy;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture", meta = (EditCondition = "bUseRingBuffer"))
+    float RingBufferDurationSeconds;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture", meta = (EditCondition = "bUseRingBuffer", ClampMin = "0"))
+    int32 RingBufferCapacityOverride;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    FString OutputDirectory;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    FString BaseFileName;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    FString ContainerFormat;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    bool bAutoAssembleVideo;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture|PNG", meta = (EditCondition = "OutputPath == ECaptureOutputPath::PNGSequence"))
+    bool bUse16BitPNG = true;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture|NVENC", meta = (EditCondition = "OutputPath == ECaptureOutputPath::NVENCVideo"))
+    bool bAutoMuxNVENC;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture|NVENC", meta = (EditCondition = "OutputPath == ECaptureOutputPath::NVENCVideo"))
+    bool bPreferD3D12Interop;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture|NVENC", meta = (EditCondition = "OutputPath == ECaptureOutputPath::NVENCVideo", ClampMin = "1"))
+    float MaxEncoderLatencyMs;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture|NVENC", meta = (EditCondition = "OutputPath == ECaptureOutputPath::NVENCVideo"))
+    FString FFmpegMuxOverride;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture|NVENC", meta = (EditCondition = "OutputPath == ECaptureOutputPath::NVENCVideo"))
+    FNVENCRateControl NVENC;
+};
+
+UCLASS(Config = EditorPerProjectUserSettings, DefaultConfig, meta = (DisplayName = "Panorama Capture"))
+class UPanoramaCaptureSettings : public UDeveloperSettings
+{
+    GENERATED_BODY()
+
+public:
+    UPanoramaCaptureSettings();
+
+    UPROPERTY(EditAnywhere, Config, Category = "Capture")
+    FCaptureOutputSettings DefaultOutput;
+
+    UPROPERTY(EditAnywhere, Config, Category = "Capture")
+    FString NVENCProfile;
+
+    UPROPERTY(EditAnywhere, Config, Category = "Audio")
+    FName AudioSubmix;
+
+    UPROPERTY(EditAnywhere, Config, Category = "Capture")
+    FString DefaultOutputDirectory;
+
+    UPROPERTY(EditAnywhere, Config, Category = "Capture")
+    bool bDefaultAutoAssemble;
+
+    UPROPERTY(EditAnywhere, Config, Category = "Capture")
+    FString FFmpegExecutable;
+};

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/CubemapCaptureRigComponent.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/CubemapCaptureRigComponent.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/SceneComponent.h"
+#include "Engine/SceneCapture2D.h"
+#include "CaptureOutputSettings.h"
+#include "CubemapCaptureRigComponent.generated.h"
+
+class UTextureRenderTarget2D;
+class UMaterialInterface;
+
+USTRUCT(BlueprintType)
+struct FPanoramaCaptureFace
+{
+    GENERATED_BODY()
+
+    FPanoramaCaptureFace()
+        : Rotation(FRotator::ZeroRotator)
+        , DebugColor(FColor::White)
+    {
+    }
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    FName Name;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    FRotator Rotation;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    FColor DebugColor;
+};
+
+UCLASS(ClassGroup = (Rendering), meta = (BlueprintSpawnableComponent))
+class PANORAMACAPTURE_API UCubemapCaptureRigComponent : public USceneComponent
+{
+    GENERATED_BODY()
+
+public:
+    UCubemapCaptureRigComponent();
+
+    UPROPERTY(Transient)
+    TArray<TObjectPtr<USceneCaptureComponent2D>> FaceCaptures;
+
+    UPROPERTY(EditAnywhere, Category = "Capture")
+    FCaptureOutputSettings OutputSettings;
+
+    UPROPERTY(EditAnywhere, Category = "Capture")
+    bool bStereo;
+
+    UPROPERTY(EditAnywhere, Category = "Capture")
+    float NearClipPlane;
+
+    UPROPERTY(EditAnywhere, Category = "Capture")
+    float FarClipPlane;
+
+    UPROPERTY(EditAnywhere, Category = "Capture")
+    TArray<FPanoramaCaptureFace> Faces;
+
+    virtual void OnRegister() override;
+    virtual void OnUnregister() override;
+
+    void InitializeRig();
+    void ReleaseRig();
+
+    void TickRig(float DeltaTime);
+
+    UTextureRenderTarget2D* GetFaceRenderTarget(int32 FaceIndex, bool bLeftEye) const;
+
+    void SetCaptureMaterial(UMaterialInterface* OverrideMaterial);
+
+protected:
+    void EnsureFaceCaptures(int32 EyeIndex);
+    void UpdateCaptureTransforms();
+
+private:
+    void ConfigureCaptureComponent(USceneCaptureComponent2D* Capture) const;
+
+    UPROPERTY(Transient)
+    TObjectPtr<UMaterialInterface> CaptureMaterial;
+
+    UPROPERTY(Transient)
+    TArray<TWeakObjectPtr<UTextureRenderTarget2D>> EyeRenderTargets;
+};

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/CubemapEquirectPass.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/CubemapEquirectPass.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RenderGraphDefinitions.h"
+#include "RHIResources.h"
+
+struct FCubemapEquirectDispatchParams
+{
+    FRDGTextureRef SourceCubemapLeft = nullptr;
+    FRDGTextureRef SourceCubemapRight = nullptr;
+    FRDGTextureRef DestinationEquirect = nullptr;
+    FIntPoint OutputResolution = FIntPoint(3840, 2160);
+    bool bStereo = false;
+    bool bLinearGamma = false;
+    bool bStereoOverUnder = true;
+};
+
+class PANORAMACAPTURE_API FCubemapEquirectPass
+{
+public:
+    static void AddComputePass(FRDGBuilder& GraphBuilder, const FCubemapEquirectDispatchParams& Params);
+};

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/PanoramaCaptureController.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/PanoramaCaptureController.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "CaptureFrameQueue.h"
+#include "CaptureOutputSettings.h"
+
+#include "Async/Future.h"
+#include "VideoEncoder.h"
+#include "Templates/Optional.h"
+
+#include "Templates/SharedPointer.h"
+
+#include "PanoramaCaptureController.generated.h"
+
+class UCubemapCaptureRigComponent;
+class UAudioComponent;
+class USoundSubmix;
+class USoundSubmixBase;
+class UTexture2D;
+class UTextRenderComponent;
+class FRHIGPUTextureReadback;
+class IPanoramaVideoEncoder;
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FPanoramaCaptureStatusChanged, FName, NewStatus);
+
+UCLASS(ClassGroup = (Rendering), meta = (BlueprintSpawnableComponent))
+class PANORAMACAPTURE_API UPanoramaCaptureController : public UActorComponent
+{
+    GENERATED_BODY()
+
+public:
+    UPanoramaCaptureController();
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Capture")
+    FCaptureOutputSettings OutputSettings;
+
+    UPROPERTY(BlueprintAssignable, Category = "Capture")
+    FPanoramaCaptureStatusChanged OnStatusChanged;
+
+    UFUNCTION(BlueprintCallable, Category = "Capture")
+    void StartCapture();
+
+    UFUNCTION(BlueprintCallable, Category = "Capture")
+    void StopCapture();
+
+    UFUNCTION(BlueprintCallable, Category = "Capture")
+    bool IsCapturing() const { return bIsCapturing; }
+
+    UFUNCTION(BlueprintCallable, Category = "Capture")
+    int32 GetDroppedFrameCount() const { return FrameBuffer.GetDroppedFrames(); }
+
+    UFUNCTION(BlueprintCallable, Category = "Capture")
+    int32 GetBufferedFrameCount() const { return FrameBuffer.Num(); }
+
+    UFUNCTION(BlueprintCallable, Category = "Capture")
+    int32 GetBlockedFrameCount() const { return FrameBuffer.GetBlockedFrames(); }
+
+    UFUNCTION(BlueprintCallable, Category = "Capture")
+    UTexture2D* GetPreviewTexture() const { return PreviewTexture; }
+
+    UFUNCTION(BlueprintCallable, Category = "Capture")
+    FString GetActiveCaptureDirectory() const { return ActiveCaptureDirectory; }
+
+protected:
+    virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+    virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+private:
+    void EnsureRig();
+    void CaptureFrame();
+    void ConsumeFrameQueue();
+    void UpdateStatus(FName NewStatus);
+    void InitializeRingBuffer();
+    void InitializeOutputDirectory();
+    void EnsureStatusDisplay();
+
+    void InitializeAudioCapture();
+    void ShutdownAudioCapture();
+    void ProcessPendingReadbacks();
+    void WritePNGFrame(FPanoramaCaptureFrame&& Frame);
+    void UpdatePreviewFromFrame(const FPanoramaCaptureFrame& Frame);
+    void FinalizeCaptureOutputs();
+    void FinalizeNVENCOutput();
+    bool AssembleWithFFmpeg(const FString& InputVideo, const FString& AudioFile, const FString& Container, bool bCopyVideoStream, double AudioOffsetSeconds);
+    FString BuildFrameFilePath(int32 FrameIndex) const;
+    FString BuildVideoFilePath(const FString& Extension) const;
+
+    UPROPERTY()
+    TObjectPtr<UCubemapCaptureRigComponent> ManagedRig;
+
+    FCaptureFrameRingBuffer FrameBuffer;
+    FTimerHandle CaptureTimerHandle;
+    bool bIsCapturing;
+    double CaptureStartSeconds;
+    int32 CaptureFrameCounter;
+
+    TArray<TSharedPtr<class FPendingCapturePayload, ESPMode::ThreadSafe>> PendingReadbacks;
+    TSharedPtr<IPanoramaVideoEncoder> ActiveEncoder;
+    FString ActiveCaptureDirectory;
+    FString ActiveBaseFileName;
+    FString ActiveElementaryStream;
+    FString RecordedAudioFile;
+    TArray<FString> CapturedFrameFiles;
+    TArray<TFuture<void>> PendingWriteTasks;
+    TArray<double> CapturedFrameTimes;
+    TOptional<double> FirstVideoTimestamp;
+    TOptional<double> LastVideoTimestamp;
+    double AudioCaptureStartSeconds;
+
+    FName CurrentStatus;
+    double LastStatusUpdateSeconds;
+
+    UPROPERTY(Transient)
+    TObjectPtr<UTexture2D> PreviewTexture;
+
+    TWeakObjectPtr<USoundSubmixBase> RecordedSubmix;
+    UPROPERTY()
+    TObjectPtr<UTextRenderComponent> StatusBillboard;
+};

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/PanoramaCaptureModule.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/PanoramaCaptureModule.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "Modules/ModuleInterface.h"
+#include "Modules/ModuleManager.h"
+
+#include "Templates/Function.h"
+#include "VideoEncoder.h"
+
+class FPanoramaCaptureModule : public IModuleInterface
+{
+public:
+    static inline FPanoramaCaptureModule& Get()
+    {
+        return FModuleManager::LoadModuleChecked<FPanoramaCaptureModule>(TEXT("PanoramaCapture"));
+    }
+
+    static inline bool IsAvailable()
+    {
+        return FModuleManager::Get().IsModuleLoaded(TEXT("PanoramaCapture"));
+    }
+
+    virtual void StartupModule() override;
+    virtual void ShutdownModule() override;
+
+    void RegisterVideoEncoderFactory(TFunction<TSharedPtr<IPanoramaVideoEncoder>()> InFactory);
+    void UnregisterVideoEncoderFactory();
+    TSharedPtr<IPanoramaVideoEncoder> CreateVideoEncoder() const;
+
+private:
+    void RegisterSettings();
+    void UnregisterSettings();
+
+    bool bShaderDirectoryRegistered = false;
+    TFunction<TSharedPtr<IPanoramaVideoEncoder>()> EncoderFactory;
+};
+
+DECLARE_LOG_CATEGORY_EXTERN(LogPanoramaCapture, Log, All);

--- a/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/VideoEncoder.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCapture/Public/VideoEncoder.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "CaptureOutputSettings.h"
+#include "RHIResources.h"
+
+/** Configuration passed to a hardware video encoder implementation. */
+struct PANORAMACAPTURE_API FPanoramaVideoEncoderConfig
+{
+    FString OutputFile;
+    FString ElementaryStreamFile;
+    FCaptureOutputSettings OutputSettings;
+    FIntPoint OutputResolution = FIntPoint::ZeroValue;
+    int32 FrameRate = 30;
+    bool bUseD3D12 = true;
+    bool bUse10Bit = false;
+};
+
+struct PANORAMACAPTURE_API FPanoramaVideoEncoderStats
+{
+    double AverageLatencyMs = 0.0;
+    int32 QueuedFrames = 0;
+    int32 SubmittedFrames = 0;
+    int32 EncodedFrames = 0;
+    int32 DroppedFrames = 0;
+};
+
+struct PANORAMACAPTURE_API FPanoramaVideoEncoderFrame
+{
+    FRHITexture* RgbaTexture = nullptr;
+    FRHITexture* LumaTexture = nullptr;
+    FRHITexture* ChromaTexture = nullptr;
+    double TimeSeconds = 0.0;
+    bool bIsNV12 = false;
+    bool bIsP010 = false;
+};
+
+/**
+ * Lightweight interface implemented by platform-specific encoders (e.g. NVENC).
+ */
+class PANORAMACAPTURE_API IPanoramaVideoEncoder : public TSharedFromThis<IPanoramaVideoEncoder, ESPMode::ThreadSafe>
+{
+public:
+    virtual ~IPanoramaVideoEncoder() = default;
+
+    virtual bool Initialize(const FPanoramaVideoEncoderConfig& InConfig) = 0;
+    virtual void EncodeFrame(const FPanoramaVideoEncoderFrame& Frame) = 0;
+    virtual void Flush() = 0;
+    virtual bool FinalizeEncoding(FString& OutElementaryStream) = 0;
+    virtual FPanoramaVideoEncoderStats GetStats() const = 0;
+
+    virtual void EncodeTexture(FRHITexture* Texture, double TimeSeconds)
+    {
+        FPanoramaVideoEncoderFrame Frame;
+        Frame.RgbaTexture = Texture;
+        Frame.TimeSeconds = TimeSeconds;
+        EncodeFrame(Frame);
+    }
+};

--- a/Plugins/PanoramaCapture/Source/PanoramaCaptureEditor/PanoramaCaptureEditor.Build.cs
+++ b/Plugins/PanoramaCapture/Source/PanoramaCaptureEditor/PanoramaCaptureEditor.Build.cs
@@ -1,0 +1,23 @@
+using UnrealBuildTool;
+
+public class PanoramaCaptureEditor : ModuleRules
+{
+    public PanoramaCaptureEditor(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+
+        PrivateDependencyModuleNames.AddRange(new[]
+        {
+            "Core",
+            "CoreUObject",
+            "Engine",
+            "Slate",
+            "SlateCore",
+            "EditorSubsystem",
+            "UnrealEd",
+            "LevelEditor",
+            "Projects",
+            "PanoramaCapture"
+        });
+    }
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCaptureEditor/Private/PanoramaCaptureEditorModule.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCaptureEditor/Private/PanoramaCaptureEditorModule.cpp
@@ -1,0 +1,726 @@
+#include "PanoramaCaptureEditorModule.h"
+
+#include "Delegates/Delegate.h"
+#include "LevelEditor.h"
+#include "PanoramaCaptureController.h"
+#include "PanoramaCaptureModule.h"
+#include "PanoramaCaptureSettings.h"
+#include "ToolMenus.h"
+#include "Framework/Commands/Commands.h"
+#include "Framework/Commands/UICommandList.h"
+#include "Framework/MultiBox/MultiBoxBuilder.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Styling/AppStyle.h"
+#include "UObject/UObjectIterator.h"
+#include "Widgets/Images/SImage.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SCheckBox.h"
+#include "Widgets/Input/SComboButton.h"
+#include "Widgets/Input/SSpinBox.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Layout/SSeparator.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SOverlay.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/SWindow.h"
+#include "Engine/Texture2D.h"
+#include "Slate/SlateBrushAsset.h"
+
+class SPanoramaPreviewWidget : public SCompoundWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SPanoramaPreviewWidget) {}
+        SLATE_ARGUMENT(TFunction<UTexture2D*()>, TextureProvider)
+        SLATE_ARGUMENT(TFunction<FText()>, StatusProvider)
+    SLATE_END_ARGS()
+
+    void Construct(const FArguments& InArgs)
+    {
+        TextureProvider = InArgs._TextureProvider;
+        StatusProvider = InArgs._StatusProvider;
+
+        PreviewBrush = MakeShared<FSlateDynamicImageBrush>(FName(), FVector2D(512.f, 256.f));
+
+        ChildSlot
+        [
+            SNew(SOverlay)
+            + SOverlay::Slot()
+            [
+                SNew(SBorder)
+                .BorderBackgroundColor(FLinearColor::Black)
+                [
+                    SNew(SBox)
+                    .WidthOverride(512.f)
+                    .HeightOverride(256.f)
+                    [
+                        SAssignNew(ImageWidget, SImage)
+                        .Image(PreviewBrush.Get())
+                    ]
+                ]
+            ]
+            + SOverlay::Slot()
+            .HAlign(HAlign_Left)
+            .VAlign(VAlign_Bottom)
+            .Padding(FMargin(8.f))
+            [
+                SAssignNew(StatusText, STextBlock)
+                .Text(StatusProvider ? StatusProvider() : FText::GetEmpty())
+                .ColorAndOpacity(FLinearColor::White)
+                .ShadowColorAndOpacity(FLinearColor::Black)
+                .ShadowOffset(FVector2D(1.f, 1.f))
+            ]
+        ];
+
+        RegisterActiveTimer(0.0f, FWidgetActiveTimerDelegate::CreateSP(this, &SPanoramaPreviewWidget::HandleActiveTimer));
+    }
+
+private:
+    EActiveTimerReturnType HandleActiveTimer(double InCurrentTime, float InDeltaTime)
+    {
+        UpdateTexture();
+        UpdateStatus();
+        return EActiveTimerReturnType::Continue;
+    }
+
+    void UpdateTexture()
+    {
+        if (!TextureProvider)
+        {
+            return;
+        }
+
+        if (UTexture2D* Texture = TextureProvider())
+        {
+            if (PreviewBrush->GetResourceObject() != Texture)
+            {
+                PreviewBrush->SetResourceObject(Texture);
+                PreviewBrush->ImageSize = FVector2D(Texture->GetSizeX(), Texture->GetSizeY());
+            }
+
+            if (ImageWidget.IsValid())
+            {
+                ImageWidget->SetImage(PreviewBrush.Get());
+            }
+        }
+    }
+
+    void UpdateStatus()
+    {
+        if (StatusProvider && StatusText.IsValid())
+        {
+            StatusText->SetText(StatusProvider());
+        }
+    }
+
+private:
+    TFunction<UTexture2D*()> TextureProvider;
+    TFunction<FText()> StatusProvider;
+    TSharedPtr<FSlateDynamicImageBrush> PreviewBrush;
+    TSharedPtr<SImage> ImageWidget;
+    TSharedPtr<STextBlock> StatusText;
+};
+
+class FPanoramaCaptureEditorCommands : public TCommands<FPanoramaCaptureEditorCommands>
+{
+public:
+    FPanoramaCaptureEditorCommands()
+        : TCommands<FPanoramaCaptureEditorCommands>(TEXT("PanoramaCaptureEditor"), NSLOCTEXT("PanoramaCaptureEditor", "Commands", "Panorama Capture"), NAME_None, FAppStyle::GetAppStyleSetName())
+    {
+    }
+
+    virtual void RegisterCommands() override
+    {
+        UI_COMMAND(ToggleCapture, "Panorama Capture", "Start or stop 360 capture.", EUserInterfaceActionType::ToggleButton, FInputChord());
+        UI_COMMAND(TogglePreview, "Panorama Preview", "Open the live panorama preview window.", EUserInterfaceActionType::ToggleButton, FInputChord());
+    }
+
+    TSharedPtr<FUICommandInfo> ToggleCapture;
+    TSharedPtr<FUICommandInfo> TogglePreview;
+};
+
+void FPanoramaCaptureEditorModule::StartupModule()
+{
+    FPanoramaCaptureEditorCommands::Register();
+
+    CommandList = MakeShared<FUICommandList>();
+    CommandList->MapAction(FPanoramaCaptureEditorCommands::Get().ToggleCapture,
+        FExecuteAction::CreateRaw(this, &FPanoramaCaptureEditorModule::HandleToggleCapture),
+        FCanExecuteAction::CreateLambda([] { return true; }),
+        FIsActionChecked::CreateRaw(this, &FPanoramaCaptureEditorModule::IsAnyControllerCapturing));
+    CommandList->MapAction(FPanoramaCaptureEditorCommands::Get().TogglePreview,
+        FExecuteAction::CreateRaw(this, &FPanoramaCaptureEditorModule::HandleTogglePreviewWindow),
+        FCanExecuteAction::CreateLambda([] { return true; }),
+        FIsActionChecked::CreateRaw(this, &FPanoramaCaptureEditorModule::IsPreviewWindowOpen));
+
+    StartupHandle = UToolMenus::RegisterStartupCallback(FSimpleMulticastDelegate::FDelegate::CreateRaw(this, &FPanoramaCaptureEditorModule::ExtendLevelEditorToolbar));
+    UpdateStatusWidget();
+}
+
+void FPanoramaCaptureEditorModule::ShutdownModule()
+{
+    if (StartupHandle.IsValid())
+    {
+        UToolMenus::UnregisterStartupCallback(StartupHandle);
+        StartupHandle = FDelegateHandle();
+    }
+    UToolMenus::UnregisterOwner(this);
+    if (PreviewWindow.IsValid())
+    {
+        PreviewWindow->RequestDestroyWindow();
+        PreviewWindow.Reset();
+    }
+    PreviewWidget.Reset();
+    FPanoramaCaptureEditorCommands::Unregister();
+    CommandList.Reset();
+    StatusWidget.Reset();
+    StatusTextBlock.Reset();
+    ControlMenuButton.Reset();
+}
+
+void FPanoramaCaptureEditorModule::ExtendLevelEditorToolbar()
+{
+    FToolMenuOwnerScoped OwnerScoped(this);
+    UToolMenu* ToolbarMenu = UToolMenus::Get()->ExtendMenu("LevelEditor.LevelEditorToolBar.PlayToolBar");
+    if (!ToolbarMenu)
+    {
+        return;
+    }
+
+    FToolMenuSection& Section = ToolbarMenu->AddSection("PanoramaCapture", NSLOCTEXT("PanoramaCaptureEditor", "Section", "Panorama"), FToolMenuInsert(TEXT("Settings"), EToolMenuInsertType::After));
+
+    FToolMenuEntry CaptureEntry = FToolMenuEntry::InitToolBarButton(FPanoramaCaptureEditorCommands::Get().ToggleCapture);
+    CaptureEntry.SetCommandList(CommandList);
+    Section.AddEntry(CaptureEntry);
+
+    FToolMenuEntry PreviewEntry = FToolMenuEntry::InitToolBarButton(FPanoramaCaptureEditorCommands::Get().TogglePreview);
+    PreviewEntry.SetCommandList(CommandList);
+    Section.AddEntry(PreviewEntry);
+
+    const TSharedRef<STextBlock> StatusText = SNew(STextBlock).Text(BuildStatusText());
+    StatusTextBlock = StatusText;
+
+    FToolMenuEntry StatusEntry = FToolMenuEntry::InitWidget(TEXT("PanoramaCaptureStatus"), StatusText, FText(), false, false);
+    Section.AddEntry(StatusEntry);
+
+    StatusWidget = StatusText;
+
+    FToolMenuEntry ControlEntry = FToolMenuEntry::InitWidget(TEXT("PanoramaCaptureControls"),
+        SAssignNew(ControlMenuButton, SComboButton)
+            .OnGetMenuContent(this, &FPanoramaCaptureEditorModule::GenerateControlMenu)
+            .ButtonContent()
+            [
+                SNew(STextBlock)
+                .Text(NSLOCTEXT("PanoramaCaptureEditor", "SettingsButton", "Panorama Settings"))
+            ],
+        NSLOCTEXT("PanoramaCaptureEditor", "SettingsTooltip", "Adjust panorama capture settings"),
+        false);
+    Section.AddEntry(ControlEntry);
+}
+
+void FPanoramaCaptureEditorModule::FillToolbar(FToolBarBuilder& Builder)
+{
+    Builder.AddToolBarButton(FPanoramaCaptureEditorCommands::Get().ToggleCapture);
+}
+
+void FPanoramaCaptureEditorModule::HandleToggleCapture()
+{
+    const bool bCapturing = IsAnyControllerCapturing();
+    ForEachController([bCapturing](UPanoramaCaptureController* Controller)
+    {
+        if (!Controller)
+        {
+            return;
+        }
+
+        if (bCapturing)
+        {
+            Controller->StopCapture();
+        }
+        else
+        {
+            Controller->StartCapture();
+        }
+    });
+
+    UpdateStatusWidget();
+}
+
+void FPanoramaCaptureEditorModule::UpdateStatusWidget()
+{
+    if (TSharedPtr<STextBlock> StatusText = StatusTextBlock.Pin())
+    {
+        StatusText->SetText(BuildStatusText());
+    }
+}
+
+TSharedRef<SWidget> FPanoramaCaptureEditorModule::GenerateControlMenu()
+{
+    UPanoramaCaptureSettings* Settings = GetMutableDefault<UPanoramaCaptureSettings>();
+    FCaptureOutputSettings& Defaults = Settings->DefaultOutput;
+
+    const bool bCapturing = IsAnyControllerCapturing();
+
+    TSharedRef<SVerticalBox> Root = SNew(SVerticalBox);
+
+    Root->AddSlot()
+        .AutoHeight()
+        .Padding(4.0f)
+        [
+            SNew(SButton)
+            .Text(bCapturing ? NSLOCTEXT("PanoramaCaptureEditor", "StopCapture", "Stop Capture") : NSLOCTEXT("PanoramaCaptureEditor", "StartCapture", "Start Capture"))
+            .OnClicked_Raw(this, &FPanoramaCaptureEditorModule::HandleStartStopButton)
+        ];
+
+    Root->AddSlot()
+        .AutoHeight()
+        .Padding(4.0f)
+        [
+            SNew(SButton)
+            .Text_Lambda([this]()
+            {
+                return IsPreviewWindowOpen()
+                    ? NSLOCTEXT("PanoramaCaptureEditor", "ClosePreview", "Close Preview")
+                    : NSLOCTEXT("PanoramaCaptureEditor", "OpenPreview", "Open Preview");
+            })
+            .OnClicked_Lambda([this]()
+            {
+                HandleTogglePreviewWindow();
+                return FReply::Handled();
+            })
+        ];
+
+    Root->AddSlot()
+        .AutoHeight()
+        .Padding(4.0f)
+        [
+            SNew(STextBlock)
+            .Text(BuildStatusText())
+        ];
+
+    Root->AddSlot()
+        .AutoHeight()
+        .Padding(2.0f)
+        [
+            SNew(SCheckBox)
+            .IsChecked(Defaults.StereoMode != EPanoramaStereoMode::Mono ? ECheckBoxState::Checked : ECheckBoxState::Unchecked)
+            .OnCheckStateChanged_Lambda([this, Settings](ECheckBoxState NewState)
+            {
+                FCaptureOutputSettings& SettingsDefaults = Settings->DefaultOutput;
+                SettingsDefaults.StereoMode = (NewState == ECheckBoxState::Checked) ? EPanoramaStereoMode::StereoOverUnder : EPanoramaStereoMode::Mono;
+                Settings->SaveConfig();
+                ApplySettingsToControllers();
+                UpdateStatusWidget();
+            })
+            .Content()[SNew(STextBlock).Text(NSLOCTEXT("PanoramaCaptureEditor", "StereoToggle", "Enable Stereo"))]
+        ];
+
+    Root->AddSlot()
+        .AutoHeight()
+        .Padding(2.0f)
+        [
+            SNew(SCheckBox)
+            .IsEnabled(Defaults.StereoMode != EPanoramaStereoMode::Mono)
+            .IsChecked(Defaults.StereoMode == EPanoramaStereoMode::StereoSideBySide ? ECheckBoxState::Checked : ECheckBoxState::Unchecked)
+            .OnCheckStateChanged_Lambda([this, Settings](ECheckBoxState NewState)
+            {
+                FCaptureOutputSettings& SettingsDefaults = Settings->DefaultOutput;
+                if (SettingsDefaults.StereoMode == EPanoramaStereoMode::Mono)
+                {
+                    return;
+                }
+                SettingsDefaults.StereoMode = (NewState == ECheckBoxState::Checked) ? EPanoramaStereoMode::StereoSideBySide : EPanoramaStereoMode::StereoOverUnder;
+                Settings->SaveConfig();
+                ApplySettingsToControllers();
+            })
+            .Content()[SNew(STextBlock).Text(NSLOCTEXT("PanoramaCaptureEditor", "StereoLayout", "Side-by-Side Layout"))]
+        ];
+
+    Root->AddSlot()
+        .AutoHeight()
+        .Padding(2.0f)
+        [
+            SNew(SCheckBox)
+            .IsChecked(Defaults.NVENC.Codec == ENVENCCodec::HEVC ? ECheckBoxState::Checked : ECheckBoxState::Unchecked)
+            .OnCheckStateChanged_Lambda([this, Settings](ECheckBoxState NewState)
+            {
+                Settings->DefaultOutput.NVENC.Codec = (NewState == ECheckBoxState::Checked) ? ENVENCCodec::HEVC : ENVENCCodec::H264;
+                Settings->SaveConfig();
+                ApplySettingsToControllers();
+            })
+            .Content()[SNew(STextBlock).Text(NSLOCTEXT("PanoramaCaptureEditor", "HEVCToggle", "Use HEVC"))]
+        ];
+
+    Root->AddSlot()
+        .AutoHeight()
+        .Padding(2.0f)
+        [
+            SNew(SCheckBox)
+            .IsChecked(Defaults.bEnablePreview ? ECheckBoxState::Checked : ECheckBoxState::Unchecked)
+            .OnCheckStateChanged_Lambda([this, Settings](ECheckBoxState NewState)
+            {
+                Settings->DefaultOutput.bEnablePreview = (NewState == ECheckBoxState::Checked);
+                Settings->SaveConfig();
+                ApplySettingsToControllers();
+                UpdateStatusWidget();
+            })
+            .Content()[SNew(STextBlock).Text(NSLOCTEXT("PanoramaCaptureEditor", "PreviewToggle", "Realtime Preview"))]
+        ];
+
+    auto MakeLabeledFloat = [&](const FText& Label, float Value, float MinValue, float MaxValue, TFunction<void(float)> OnCommit)
+    {
+        return SNew(SHorizontalBox)
+            + SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(0.0f, 0.0f, 8.0f, 0.0f)
+            [
+                SNew(STextBlock).Text(Label)
+            ]
+            + SHorizontalBox::Slot().FillWidth(1.0f)
+            [
+                SNew(SSpinBox<float>)
+                .MinValue(MinValue)
+                .MaxValue(MaxValue)
+                .Value(Value)
+                .OnValueCommitted_Lambda([OnCommit](float NewValue, ETextCommit::Type)
+                {
+                    OnCommit(NewValue);
+                })
+            ];
+    };
+
+    Root->AddSlot().AutoHeight().Padding(2.0f)
+        [MakeLabeledFloat(NSLOCTEXT("PanoramaCaptureEditor", "BitrateLabel", "Bitrate (Mbps)"), Defaults.NVENC.BitrateMbps, 1.0f, 2000.0f, [this, Settings](float NewValue)
+        {
+            Settings->DefaultOutput.NVENC.BitrateMbps = NewValue;
+            Settings->SaveConfig();
+            ApplySettingsToControllers();
+        })];
+
+    Root->AddSlot().AutoHeight().Padding(2.0f)
+        [MakeLabeledFloat(NSLOCTEXT("PanoramaCaptureEditor", "MaxBitrateLabel", "Max Bitrate (Mbps)"), Defaults.NVENC.MaxBitrateMbps, 1.0f, 4000.0f, [this, Settings](float NewValue)
+        {
+            Settings->DefaultOutput.NVENC.MaxBitrateMbps = NewValue;
+            Settings->SaveConfig();
+            ApplySettingsToControllers();
+        })];
+
+    auto MakeLabeledInt = [&](const FText& Label, int32 Value, int32 MinValue, int32 MaxValue, TFunction<void(int32)> OnCommit)
+    {
+        return SNew(SHorizontalBox)
+            + SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(0.0f, 0.0f, 8.0f, 0.0f)
+            [
+                SNew(STextBlock).Text(Label)
+            ]
+            + SHorizontalBox::Slot().FillWidth(1.0f)
+            [
+                SNew(SSpinBox<int32>)
+                .MinValue(MinValue)
+                .MaxValue(MaxValue)
+                .Value(Value)
+                .OnValueCommitted_Lambda([OnCommit](int32 NewValue, ETextCommit::Type)
+                {
+                    OnCommit(NewValue);
+                })
+            ];
+    };
+
+    Root->AddSlot().AutoHeight().Padding(2.0f)
+        [MakeLabeledInt(NSLOCTEXT("PanoramaCaptureEditor", "GOPLabel", "GOP Length"), Defaults.NVENC.GOPLength, 1, 600, [this, Settings](int32 NewValue)
+        {
+            Settings->DefaultOutput.NVENC.GOPLength = NewValue;
+            Settings->SaveConfig();
+            ApplySettingsToControllers();
+        })];
+
+    Root->AddSlot().AutoHeight().Padding(2.0f)
+        [MakeLabeledInt(NSLOCTEXT("PanoramaCaptureEditor", "BFrameLabel", "B-Frames"), Defaults.NVENC.BFrameCount, 0, 6, [this, Settings](int32 NewValue)
+        {
+            Settings->DefaultOutput.NVENC.BFrameCount = NewValue;
+            Settings->DefaultOutput.NVENC.bEnableBFrames = (NewValue > 0);
+            Settings->SaveConfig();
+            ApplySettingsToControllers();
+        })];
+
+    Root->AddSlot().AutoHeight().Padding(2.0f)
+        [MakeLabeledFloat(NSLOCTEXT("PanoramaCaptureEditor", "RingBufferSeconds", "Ring Buffer Seconds"), Defaults.RingBufferDurationSeconds, 0.1f, 30.0f, [this, Settings](float NewValue)
+        {
+            Settings->DefaultOutput.RingBufferDurationSeconds = NewValue;
+            Settings->SaveConfig();
+            ApplySettingsToControllers();
+        })];
+
+    Root->AddSlot().AutoHeight().Padding(2.0f)
+        [MakeLabeledInt(NSLOCTEXT("PanoramaCaptureEditor", "RingBufferCapacity", "Ring Buffer Capacity"), Defaults.RingBufferCapacityOverride, 0, 2048, [this, Settings](int32 NewValue)
+        {
+            Settings->DefaultOutput.RingBufferCapacityOverride = NewValue;
+            Settings->SaveConfig();
+            ApplySettingsToControllers();
+        })];
+
+    Root->AddSlot().AutoHeight().Padding(2.0f)
+        [MakeLabeledFloat(NSLOCTEXT("PanoramaCaptureEditor", "PreviewScale", "Preview Scale"), Defaults.PreviewScale, 0.1f, 1.0f, [this, Settings](float NewValue)
+        {
+            Settings->DefaultOutput.PreviewScale = NewValue;
+            Settings->SaveConfig();
+            ApplySettingsToControllers();
+        })];
+
+    Root->AddSlot().AutoHeight().Padding(2.0f)
+        [
+            SNew(SCheckBox)
+            .IsChecked(Defaults.GammaSpace == EPanoramaGammaSpace::Linear ? ECheckBoxState::Checked : ECheckBoxState::Unchecked)
+            .OnCheckStateChanged_Lambda([this, Settings](ECheckBoxState NewState)
+            {
+                Settings->DefaultOutput.GammaSpace = (NewState == ECheckBoxState::Checked) ? EPanoramaGammaSpace::Linear : EPanoramaGammaSpace::sRGB;
+                Settings->SaveConfig();
+                ApplySettingsToControllers();
+            })
+            .Content()[SNew(STextBlock).Text(NSLOCTEXT("PanoramaCaptureEditor", "LinearGamma", "Linear Gamma"))]
+        ];
+
+    TArray<TSharedPtr<FString>> PolicyOptions;
+    PolicyOptions.Add(MakeShared<FString>(TEXT("Drop Oldest")));
+    PolicyOptions.Add(MakeShared<FString>(TEXT("Drop Newest")));
+    PolicyOptions.Add(MakeShared<FString>(TEXT("Block")));
+
+    auto ResolvePolicyLabel = [&]() -> TSharedPtr<FString>
+    {
+        switch (Defaults.RingBufferPolicy)
+        {
+        case ERingBufferOverflowPolicy::DropNewest: return PolicyOptions[1];
+        case ERingBufferOverflowPolicy::BlockUntilAvailable: return PolicyOptions[2];
+        default: return PolicyOptions[0];
+        }
+    };
+
+    Root->AddSlot().AutoHeight().Padding(2.0f)
+        [
+            SNew(SHorizontalBox)
+            + SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(0.0f, 0.0f, 8.0f, 0.0f)
+            [
+                SNew(STextBlock).Text(NSLOCTEXT("PanoramaCaptureEditor", "RingPolicy", "Ring Buffer Policy"))
+            ]
+            + SHorizontalBox::Slot().FillWidth(1.0f)
+            [
+                SNew(SComboBox<TSharedPtr<FString>>)
+                .OptionsSource(&PolicyOptions)
+                .InitiallySelectedItem(ResolvePolicyLabel())
+                .OnGenerateWidget_Lambda([](TSharedPtr<FString> Item)
+                {
+                    return SNew(STextBlock).Text(FText::FromString(*Item));
+                })
+                .OnSelectionChanged_Lambda([this, Settings, PolicyOptions](TSharedPtr<FString> Item, ESelectInfo::Type)
+                {
+                    if (!Item.IsValid())
+                    {
+                        return;
+                    }
+                    if (*Item == *PolicyOptions[1])
+                    {
+                        Settings->DefaultOutput.RingBufferPolicy = ERingBufferOverflowPolicy::DropNewest;
+                    }
+                    else if (*Item == *PolicyOptions[2])
+                    {
+                        Settings->DefaultOutput.RingBufferPolicy = ERingBufferOverflowPolicy::BlockUntilAvailable;
+                    }
+                    else
+                    {
+                        Settings->DefaultOutput.RingBufferPolicy = ERingBufferOverflowPolicy::DropOldest;
+                    }
+                    Settings->SaveConfig();
+                    ApplySettingsToControllers();
+                })
+                .Content()
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(*ResolvePolicyLabel()))
+                ]
+            ]
+        ];
+
+    Root->AddSlot().AutoHeight().Padding(2.0f)
+        [
+            SNew(SCheckBox)
+            .IsChecked(Defaults.bAutoMuxNVENC ? ECheckBoxState::Checked : ECheckBoxState::Unchecked)
+            .OnCheckStateChanged_Lambda([this, Settings](ECheckBoxState NewState)
+            {
+                Settings->DefaultOutput.bAutoMuxNVENC = (NewState == ECheckBoxState::Checked);
+                Settings->SaveConfig();
+            })
+            .Content()[SNew(STextBlock).Text(NSLOCTEXT("PanoramaCaptureEditor", "MuxToggle", "Auto-mux NVENC output"))]
+        ];
+
+    return Root;
+}
+
+FReply FPanoramaCaptureEditorModule::HandleStartStopButton()
+{
+    HandleToggleCapture();
+    if (TSharedPtr<SComboButton> Combo = ControlMenuButton.Pin())
+    {
+        Combo->SetIsOpen(false);
+    }
+    return FReply::Handled();
+}
+
+void FPanoramaCaptureEditorModule::HandleTogglePreviewWindow()
+{
+    if (PreviewWindow.IsValid())
+    {
+        PreviewWindow->RequestDestroyWindow();
+        PreviewWindow.Reset();
+        PreviewWidget.Reset();
+        return;
+    }
+
+    TSharedRef<SWindow> Window = SNew(SWindow)
+        .Title(NSLOCTEXT("PanoramaCaptureEditor", "PreviewWindowTitle", "Panorama Preview"))
+        .SupportsMaximize(false)
+        .SupportsMinimize(true)
+        .SizingRule(ESizingRule::Autosized);
+
+    Window->SetContent(
+        SAssignNew(PreviewWidget, SPanoramaPreviewWidget)
+        .TextureProvider([this]() { return ResolvePreviewTexture(); })
+        .StatusProvider([this]() { return BuildPreviewStatusText(); })
+    );
+
+    PreviewWindow = Window;
+    Window->SetOnWindowClosed(FOnWindowClosed::CreateLambda([this](const TSharedRef<SWindow>&)
+    {
+        PreviewWindow.Reset();
+        PreviewWidget.Reset();
+    }));
+    FSlateApplication::Get().AddWindow(Window);
+}
+
+bool FPanoramaCaptureEditorModule::IsPreviewWindowOpen() const
+{
+    return PreviewWindow.IsValid();
+}
+
+UTexture2D* FPanoramaCaptureEditorModule::ResolvePreviewTexture() const
+{
+    UTexture2D* Result = nullptr;
+    ForEachController([&Result](UPanoramaCaptureController* Controller)
+    {
+        if (Result || !Controller)
+        {
+            return;
+        }
+
+        if (UTexture2D* Preview = Controller->GetPreviewTexture())
+        {
+            Result = Preview;
+        }
+    });
+    return Result;
+}
+
+FText FPanoramaCaptureEditorModule::BuildPreviewStatusText() const
+{
+    return BuildStatusText();
+}
+
+void FPanoramaCaptureEditorModule::ApplySettingsToControllers()
+{
+    UPanoramaCaptureSettings* Settings = GetMutableDefault<UPanoramaCaptureSettings>();
+    FCaptureOutputSettings& Defaults = Settings->DefaultOutput;
+    ForEachController([&Defaults](UPanoramaCaptureController* Controller)
+    {
+        if (Controller && !Controller->IsCapturing())
+        {
+            Controller->OutputSettings = Defaults;
+        }
+    });
+}
+
+void FPanoramaCaptureEditorModule::ForEachController(TFunctionRef<void(UPanoramaCaptureController*)> InFunc)
+{
+    for (TObjectIterator<UPanoramaCaptureController> It; It; ++It)
+    {
+        if (It->IsTemplate())
+        {
+            continue;
+        }
+
+        if (UPanoramaCaptureController* Controller = *It)
+        {
+            if (Controller->GetWorld() && !Controller->GetWorld()->IsPreviewWorld())
+            {
+                InFunc(Controller);
+            }
+        }
+    }
+}
+
+bool FPanoramaCaptureEditorModule::IsAnyControllerCapturing() const
+{
+    bool bCapturing = false;
+    ForEachController([&bCapturing](UPanoramaCaptureController* Controller)
+    {
+        if (Controller && Controller->IsCapturing())
+        {
+            bCapturing = true;
+        }
+    });
+    return bCapturing;
+}
+
+FText FPanoramaCaptureEditorModule::BuildStatusText() const
+{
+    int32 ControllerCount = 0;
+    int32 CapturingCount = 0;
+    int32 BufferedFrames = 0;
+    int32 DroppedFrames = 0;
+    int32 BlockedFrames = 0;
+
+    ForEachController([&](UPanoramaCaptureController* Controller)
+    {
+        if (!Controller)
+        {
+            return;
+        }
+
+        ++ControllerCount;
+        if (Controller->IsCapturing())
+        {
+            ++CapturingCount;
+        }
+
+        BufferedFrames += Controller->GetBufferedFrameCount();
+        DroppedFrames += Controller->GetDroppedFrameCount();
+        BlockedFrames += Controller->GetBlockedFrameCount();
+    });
+
+    FString Label;
+    if (CapturingCount > 0)
+    {
+        Label = FString::Printf(TEXT("Recording (%d/%d)"), CapturingCount, FMath::Max(1, ControllerCount));
+    }
+    else
+    {
+        Label = TEXT("Idle");
+    }
+
+    Label += FString::Printf(TEXT(" | Buffer:%d | Dropped:%d"), BufferedFrames, DroppedFrames);
+    if (BlockedFrames > 0)
+    {
+        Label += FString::Printf(TEXT(" | Blocked:%d"), BlockedFrames);
+    }
+
+    if (const UPanoramaCaptureSettings* Settings = GetDefault<UPanoramaCaptureSettings>())
+    {
+        if (!Settings->DefaultOutput.bEnablePreview)
+        {
+            Label += TEXT(" | Preview Off");
+        }
+        if (Settings->DefaultOutput.OutputPath == ECaptureOutputPath::NVENCVideo && Settings->DefaultOutput.NVENC.Codec == ENVENCCodec::HEVC)
+        {
+            Label += TEXT(" | HEVC");
+        }
+    }
+
+    return FText::FromString(Label);
+}
+
+IMPLEMENT_MODULE(FPanoramaCaptureEditorModule, PanoramaCaptureEditor)

--- a/Plugins/PanoramaCapture/Source/PanoramaCaptureEditor/Public/PanoramaCaptureEditorModule.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCaptureEditor/Public/PanoramaCaptureEditorModule.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "Modules/ModuleInterface.h"
+#include "Modules/ModuleManager.h"
+
+class FUICommandList;
+
+class FPanoramaCaptureEditorModule : public IModuleInterface
+{
+public:
+    virtual void StartupModule() override;
+    virtual void ShutdownModule() override;
+
+private:
+    void ExtendLevelEditorToolbar();
+    void HandleToggleCapture();
+    void UpdateStatusWidget();
+    TSharedRef<class SWidget> GenerateControlMenu();
+    FReply HandleStartStopButton();
+    void ApplySettingsToControllers();
+    void HandleTogglePreviewWindow();
+    bool IsPreviewWindowOpen() const;
+    class UTexture2D* ResolvePreviewTexture() const;
+    FText BuildPreviewStatusText() const;
+    static void ForEachController(TFunctionRef<void(class UPanoramaCaptureController*)> InFunc);
+    bool IsAnyControllerCapturing() const;
+    FText BuildStatusText() const;
+
+    TSharedPtr<FUICommandList> CommandList;
+    TWeakPtr<class SWidget> StatusWidget;
+    TWeakPtr<class STextBlock> StatusTextBlock;
+    TWeakPtr<class SComboButton> ControlMenuButton;
+    TSharedPtr<class SWindow> PreviewWindow;
+    TWeakPtr<class SPanoramaPreviewWidget> PreviewWidget;
+    FDelegateHandle StartupHandle;
+};

--- a/Plugins/PanoramaCapture/Source/PanoramaCaptureNVENC/PanoramaCaptureNVENC.Build.cs
+++ b/Plugins/PanoramaCapture/Source/PanoramaCaptureNVENC/PanoramaCaptureNVENC.Build.cs
@@ -1,0 +1,45 @@
+using UnrealBuildTool;
+using System;
+using System.IO;
+
+public class PanoramaCaptureNVENC : ModuleRules
+{
+    public PanoramaCaptureNVENC(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+
+        PublicDependencyModuleNames.AddRange(new[]
+        {
+            "Core",
+            "CoreUObject",
+            "Engine",
+            "RHI",
+            "RenderCore",
+            "PanoramaCapture"
+        });
+
+        PrivateDependencyModuleNames.Add("Projects");
+
+        if (Target.Platform == UnrealTargetPlatform.Win64)
+        {
+            PublicDefinitions.Add("WITH_PANORAMA_NVENC=1");
+            PrivateDependencyModuleNames.Add("D3D11RHI");
+            PrivateDependencyModuleNames.Add("D3D12RHI");
+            PublicDelayLoadDLLs.Add("nvEncodeAPI64.dll");
+
+            string NvencSdk = Environment.GetEnvironmentVariable("NVENC_SDK_DIR");
+            if (!string.IsNullOrEmpty(NvencSdk))
+            {
+                string IncludePath = Path.Combine(NvencSdk, "Include");
+                if (Directory.Exists(IncludePath))
+                {
+                    PrivateIncludePaths.Add(IncludePath);
+                }
+            }
+        }
+        else
+        {
+            PublicDefinitions.Add("WITH_PANORAMA_NVENC=0");
+        }
+    }
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCaptureNVENC/Private/NVENCEncoder.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCaptureNVENC/Private/NVENCEncoder.cpp
@@ -1,0 +1,481 @@
+#include "NVENCEncoder.h"
+
+#include "PanoramaCaptureModule.h"
+#include "PanoramaCaptureNVENCModule.h"
+
+#include "HAL/FileManager.h"
+#include "HAL/PlatformProcess.h"
+#include "Async/TaskGraphInterfaces.h"
+#include "Misc/Paths.h"
+#include "Misc/ScopeLock.h"
+#include "RHIResources.h"
+
+#if PLATFORM_WINDOWS && WITH_PANORAMA_NVENC
+#include "Windows/AllowWindowsPlatformTypes.h"
+#include <d3d11.h>
+#include "nvEncodeAPI.h"
+#include "Windows/HideWindowsPlatformTypes.h"
+#include "D3D11RHIPrivate.h"
+#include "D3D11RHI.h"
+#include "D3D12RHIPrivate.h"
+#include "D3D12RHI.h"
+#endif
+
+FPanoramaNVENCEncoder::FPanoramaNVENCEncoder()
+    : bInitialized(false)
+    , bUsingD3D12(false)
+    , EncoderInterface(nullptr)
+    , DeviceHandle(nullptr)
+    , FunctionList(nullptr)
+    , NvEncLibraryHandle(nullptr)
+    , TotalEncodeLatencySeconds(0.0)
+{
+}
+
+FPanoramaNVENCEncoder::~FPanoramaNVENCEncoder()
+{
+    FString DummyOutput;
+    FinalizeEncoding(DummyOutput);
+}
+
+bool FPanoramaNVENCEncoder::Initialize(const FPanoramaVideoEncoderConfig& InConfig)
+{
+    Config = InConfig;
+    Stats = FPanoramaVideoEncoderStats();
+    TotalEncodeLatencySeconds = 0.0;
+
+#if PLATFORM_WINDOWS && WITH_PANORAMA_NVENC
+    if (!InitializeSession())
+    {
+        UE_LOG(LogPanoramaNVENC, Error, TEXT("Failed to initialize NVENC session."));
+        ShutdownSession();
+        return false;
+    }
+
+    IFileManager::Get().Delete(*Config.ElementaryStreamFile);
+    ElementaryStreamWriter.Reset(IFileManager::Get().CreateFileWriter(*Config.ElementaryStreamFile, FILEWRITE_EvenIfReadOnly | FILEWRITE_AllowRead));
+    if (!ElementaryStreamWriter)
+    {
+        UE_LOG(LogPanoramaNVENC, Error, TEXT("Unable to open elementary stream file '%s' for writing."), *Config.ElementaryStreamFile);
+        ShutdownSession();
+        return false;
+    }
+
+    bInitialized = true;
+    UE_LOG(LogPanoramaNVENC, Log, TEXT("NVENC initialized: %dx%d @ %d FPS (%s)."),
+        Config.OutputResolution.X,
+        Config.OutputResolution.Y,
+        Config.FrameRate,
+        (Config.OutputSettings.NVENC.Codec == ENVENCCodec::HEVC) ? TEXT("HEVC") : TEXT("H.264"));
+    return true;
+#else
+    UE_LOG(LogPanoramaNVENC, Warning, TEXT("NVENC initialization attempted on unsupported platform."));
+    return false;
+#endif
+}
+
+void FPanoramaNVENCEncoder::EncodeFrame(const FPanoramaVideoEncoderFrame& Frame)
+{
+#if PLATFORM_WINDOWS && WITH_PANORAMA_NVENC
+    if (!bInitialized || (!Frame.RgbaTexture && !Frame.LumaTexture))
+    {
+        return;
+    }
+
+    Stats.SubmittedFrames++;
+
+    FEncodeSubmission Submission;
+    Submission.Frame = Frame;
+
+    FGraphEventRef PrevTask = LastEncodeTask;
+    LastEncodeTask = FFunctionGraphTask::CreateAndDispatchWhenReady([this, Submission]()
+    {
+        EncodeSubmission(Submission);
+    }, TStatId(), PrevTask);
+#else
+    UE_LOG(LogPanoramaNVENC, Warning, TEXT("EncodeFrame called without NVENC support."));
+#endif
+}
+
+void FPanoramaNVENCEncoder::Flush()
+{
+#if PLATFORM_WINDOWS && WITH_PANORAMA_NVENC
+    FlushPendingTasks();
+#endif
+}
+
+bool FPanoramaNVENCEncoder::FinalizeEncoding(FString& OutElementaryStream)
+{
+#if PLATFORM_WINDOWS && WITH_PANORAMA_NVENC
+    if (!bInitialized)
+    {
+        OutElementaryStream.Reset();
+        return false;
+    }
+
+    Flush();
+
+    if (FunctionList && EncoderInterface)
+    {
+        FunctionList->nvEncFlushEncoderQueue(EncoderInterface, nullptr);
+    }
+
+    if (ElementaryStreamWriter)
+    {
+        ElementaryStreamWriter->Close();
+        ElementaryStreamWriter.Reset();
+    }
+
+    OutElementaryStream = Config.ElementaryStreamFile;
+
+    ShutdownSession();
+    bInitialized = false;
+    return true;
+#else
+    OutElementaryStream.Reset();
+    return false;
+#endif
+}
+
+FPanoramaVideoEncoderStats FPanoramaNVENCEncoder::GetStats() const
+{
+#if PLATFORM_WINDOWS && WITH_PANORAMA_NVENC
+    FScopeLock Lock(&EncodeCriticalSection);
+    FPanoramaVideoEncoderStats Result = Stats;
+    Result.QueuedFrames = FMath::Max(0, Stats.SubmittedFrames - Stats.EncodedFrames);
+    if (Stats.EncodedFrames > 0)
+    {
+        Result.AverageLatencyMs = (TotalEncodeLatencySeconds / static_cast<double>(Stats.EncodedFrames)) * 1000.0;
+    }
+    return Result;
+#else
+    return FPanoramaVideoEncoderStats();
+#endif
+}
+
+#if PLATFORM_WINDOWS && WITH_PANORAMA_NVENC
+
+namespace
+{
+    const GUID& GetCodecGuid(const FPanoramaVideoEncoderConfig& Config)
+    {
+        return (Config.OutputSettings.NVENC.Codec == ENVENCCodec::HEVC) ? NV_ENC_CODEC_HEVC_GUID : NV_ENC_CODEC_H264_GUID;
+    }
+
+    NV_ENC_BUFFER_FORMAT GetBufferFormat(const FPanoramaVideoEncoderConfig& Config)
+    {
+        return Config.bUse10Bit ? NV_ENC_BUFFER_FORMAT_ABGR10 : NV_ENC_BUFFER_FORMAT_ABGR;
+    }
+
+    NV_ENC_PARAMS_RC_MODE GetRateControlMode(const FNVENCRateControl& RateControl)
+    {
+        switch (RateControl.RateControlMode)
+        {
+        case ENVENCRateControlMode::CQP:
+            return NV_ENC_PARAMS_RC_CONSTQP;
+        case ENVENCRateControlMode::VBR:
+            return NV_ENC_PARAMS_RC_VBR;
+        default:
+            return NV_ENC_PARAMS_RC_CBR;
+        }
+    }
+}
+
+bool FPanoramaNVENCEncoder::InitializeSession()
+{
+    FString RHIName = GDynamicRHI ? GDynamicRHI->GetName() : TEXT("");
+    bUsingD3D12 = Config.bUseD3D12 && RHIName.Contains(TEXT("D3D12"));
+
+    if (bUsingD3D12)
+    {
+        FD3D12DynamicRHI* D3D12RHI = static_cast<FD3D12DynamicRHI*>(GDynamicRHI);
+        DeviceHandle = D3D12RHI ? D3D12RHI->RHIGetDevice() : nullptr;
+    }
+    else
+    {
+        FD3D11DynamicRHI* D3D11RHI = static_cast<FD3D11DynamicRHI*>(GDynamicRHI);
+        DeviceHandle = D3D11RHI ? D3D11RHI->RHIGetDevice() : nullptr;
+    }
+
+    if (!DeviceHandle)
+    {
+        UE_LOG(LogPanoramaNVENC, Error, TEXT("Failed to acquire native RHI device for NVENC."));
+        return false;
+    }
+
+    NvEncLibraryHandle = FPlatformProcess::GetDllHandle(TEXT("nvEncodeAPI64.dll"));
+    if (!NvEncLibraryHandle)
+    {
+        UE_LOG(LogPanoramaNVENC, Error, TEXT("Unable to load nvEncodeAPI64.dll."));
+        return false;
+    }
+
+    FunctionList = new NV_ENCODE_API_FUNCTION_LIST();
+    FMemory::Memzero(FunctionList, sizeof(NV_ENCODE_API_FUNCTION_LIST));
+    FunctionList->version = NV_ENCODE_API_FUNCTION_LIST_VER;
+
+    if (NVENCSTATUS Status = NvEncodeAPICreateInstance(FunctionList); Status != NV_ENC_SUCCESS)
+    {
+        UE_LOG(LogPanoramaNVENC, Error, TEXT("NvEncodeAPICreateInstance failed (%d)."), static_cast<int32>(Status));
+        return false;
+    }
+
+    NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS SessionParams = {};
+    SessionParams.version = NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS_VER;
+    SessionParams.device = DeviceHandle;
+    SessionParams.deviceType = bUsingD3D12 ? NV_ENC_DEVICE_TYPE_DIRECTX12 : NV_ENC_DEVICE_TYPE_DIRECTX;
+    SessionParams.apiVersion = NVENCAPI_VERSION;
+
+    if (NVENCSTATUS Status = FunctionList->nvEncOpenEncodeSessionEx(&SessionParams, &EncoderInterface); Status != NV_ENC_SUCCESS)
+    {
+        UE_LOG(LogPanoramaNVENC, Error, TEXT("nvEncOpenEncodeSessionEx failed (%d)."), static_cast<int32>(Status));
+        return false;
+    }
+
+    NV_ENC_CONFIG EncodeConfig = {};
+    EncodeConfig.version = NV_ENC_CONFIG_VER;
+    EncodeConfig.profileGUID = (Config.OutputSettings.NVENC.Codec == ENVENCCodec::HEVC) ? NV_ENC_HEVC_PROFILE_MAIN_GUID : NV_ENC_H264_PROFILE_HIGH_GUID;
+    EncodeConfig.gopLength = Config.OutputSettings.NVENC.GOPLength;
+    EncodeConfig.frameIntervalP = Config.OutputSettings.NVENC.bEnableBFrames ? Config.OutputSettings.NVENC.BFrameCount + 1 : 1;
+    EncodeConfig.mvPrecision = NV_ENC_MV_PRECISION_QUARTER_PEL;
+
+    NV_ENC_RC_PARAMS& RC = EncodeConfig.rcParams;
+    RC.version = NV_ENC_RC_PARAMS_VER;
+    RC.rateControlMode = GetRateControlMode(Config.OutputSettings.NVENC);
+    RC.averageBitRate = static_cast<uint32>(Config.OutputSettings.NVENC.BitrateMbps * 1000000.0f);
+    RC.maxBitRate = static_cast<uint32>(Config.OutputSettings.NVENC.MaxBitrateMbps * 1000000.0f);
+    RC.vbvBufferSize = static_cast<uint32>(RC.averageBitRate * Config.OutputSettings.NVENC.VBVMultiplier);
+    RC.vbvInitialDelay = RC.vbvBufferSize;
+    RC.zeroReorderDelay = Config.OutputSettings.NVENC.bZeroLatency ? 1 : 0;
+    RC.enableAQ = Config.OutputSettings.NVENC.bZeroLatency ? 0 : 1;
+
+    NV_ENC_INITIALIZE_PARAMS InitParams = {};
+    InitParams.version = NV_ENC_INITIALIZE_PARAMS_VER;
+    InitParams.encodeGUID = GetCodecGuid(Config);
+    InitParams.presetGUID = NV_ENC_PRESET_P3_GUID;
+    InitParams.encodeWidth = Config.OutputResolution.X;
+    InitParams.encodeHeight = Config.OutputResolution.Y;
+    InitParams.darWidth = Config.OutputResolution.X;
+    InitParams.darHeight = Config.OutputResolution.Y;
+    InitParams.frameRateNum = Config.FrameRate;
+    InitParams.frameRateDen = 1;
+    InitParams.enablePTD = 1;
+    InitParams.encodeConfig = &EncodeConfig;
+
+    if (NVENCSTATUS Status = FunctionList->nvEncInitializeEncoder(EncoderInterface, &InitParams); Status != NV_ENC_SUCCESS)
+    {
+        UE_LOG(LogPanoramaNVENC, Error, TEXT("nvEncInitializeEncoder failed (%d)."), static_cast<int32>(Status));
+        return false;
+    }
+
+    const int32 BufferCount = FMath::Max(2, Config.OutputSettings.NVENC.AsyncDepth);
+    AvailableBitstreams.Reserve(BufferCount);
+
+    for (int32 Index = 0; Index < BufferCount; ++Index)
+    {
+        NV_ENC_CREATE_BITSTREAM_BUFFER BitstreamParams = {};
+        BitstreamParams.version = NV_ENC_CREATE_BITSTREAM_BUFFER_VER;
+        if (NVENCSTATUS Status = FunctionList->nvEncCreateBitstreamBuffer(EncoderInterface, &BitstreamParams); Status != NV_ENC_SUCCESS)
+        {
+            UE_LOG(LogPanoramaNVENC, Error, TEXT("nvEncCreateBitstreamBuffer failed (%d)."), static_cast<int32>(Status));
+            return false;
+        }
+        AvailableBitstreams.Add(BitstreamParams.bitstreamBuffer);
+    }
+
+    return true;
+}
+
+void FPanoramaNVENCEncoder::ShutdownSession()
+{
+    FlushPendingTasks();
+
+    if (FunctionList && EncoderInterface)
+    {
+        for (TPair<FRHITexture*, FRegisteredResource>& Pair : RegisteredResources)
+        {
+            if (Pair.Value.RegisteredHandle)
+            {
+                FunctionList->nvEncUnregisterResource(EncoderInterface, Pair.Value.RegisteredHandle);
+            }
+        }
+        RegisteredResources.Empty();
+
+        for (void* Bitstream : AvailableBitstreams)
+        {
+            if (Bitstream)
+            {
+                FunctionList->nvEncDestroyBitstreamBuffer(EncoderInterface, Bitstream);
+            }
+        }
+        AvailableBitstreams.Empty();
+
+        FunctionList->nvEncDestroyEncoder(EncoderInterface);
+        EncoderInterface = nullptr;
+    }
+
+    if (FunctionList)
+    {
+        delete FunctionList;
+        FunctionList = nullptr;
+    }
+
+    if (NvEncLibraryHandle)
+    {
+        FPlatformProcess::FreeDllHandle(NvEncLibraryHandle);
+        NvEncLibraryHandle = nullptr;
+    }
+}
+
+bool FPanoramaNVENCEncoder::RegisterIfNeeded(FRHITexture* Texture, void** OutRegisteredHandle)
+{
+    if (FRegisteredResource* Existing = RegisteredResources.Find(Texture))
+    {
+        *OutRegisteredHandle = Existing->RegisteredHandle;
+        return true;
+    }
+
+    FTextureRHIRef TextureRef = Texture;
+    void* NativeResource = TextureRef->GetNativeResource();
+    if (!NativeResource)
+    {
+        return false;
+    }
+
+    NV_ENC_REGISTER_RESOURCE RegisterParams = {};
+    RegisterParams.version = NV_ENC_REGISTER_RESOURCE_VER;
+    RegisterParams.resourceType = bUsingD3D12 ? NV_ENC_INPUT_RESOURCE_TYPE_DIRECTX12 : NV_ENC_INPUT_RESOURCE_TYPE_DIRECTX;
+    RegisterParams.resourceToRegister = NativeResource;
+    RegisterParams.width = Config.OutputResolution.X;
+    RegisterParams.height = Config.OutputResolution.Y;
+    RegisterParams.bufferFormat = GetBufferFormat(Config);
+    RegisterParams.bufferUsage = NV_ENC_INPUT_IMAGE;
+
+    if (NVENCSTATUS Status = FunctionList->nvEncRegisterResource(EncoderInterface, &RegisterParams); Status != NV_ENC_SUCCESS)
+    {
+        UE_LOG(LogPanoramaNVENC, Error, TEXT("nvEncRegisterResource failed (%d)."), static_cast<int32>(Status));
+        return false;
+    }
+
+    FRegisteredResource Registered;
+    Registered.Texture = Texture;
+    Registered.RegisteredHandle = RegisterParams.registeredResource;
+    RegisteredResources.Add(Texture, Registered);
+
+    *OutRegisteredHandle = RegisterParams.registeredResource;
+    return true;
+}
+
+void FPanoramaNVENCEncoder::EncodeSubmission(const FEncodeSubmission& Submission)
+{
+    FScopeLock Lock(&EncodeCriticalSection);
+
+    if (!bInitialized)
+    {
+        return;
+    }
+
+    if (!Submission.Frame.RgbaTexture)
+    {
+        UE_LOG(LogPanoramaNVENC, Warning, TEXT("NVENC submission missing RGBA texture. Skipping frame."));
+        ++Stats.DroppedFrames;
+        return;
+    }
+
+    const double SubmissionTime = Submission.Frame.TimeSeconds;
+    FRHITexture* Texture = Submission.Frame.RgbaTexture;
+
+    void* RegisteredHandle = nullptr;
+    if (!RegisterIfNeeded(Texture, &RegisteredHandle))
+    {
+        ++Stats.DroppedFrames;
+        return;
+    }
+
+    if (AvailableBitstreams.Num() == 0)
+    {
+        UE_LOG(LogPanoramaNVENC, Warning, TEXT("NVENC bitstream pool exhausted. Dropping frame."));
+        ++Stats.DroppedFrames;
+        return;
+    }
+
+    void* Bitstream = AvailableBitstreams.Pop(false);
+
+    NV_ENC_MAP_INPUT_RESOURCE MapParams = {};
+    MapParams.version = NV_ENC_MAP_INPUT_RESOURCE_VER;
+    MapParams.registeredResource = RegisteredHandle;
+
+    if (NVENCSTATUS Status = FunctionList->nvEncMapInputResource(EncoderInterface, &MapParams); Status != NV_ENC_SUCCESS)
+    {
+        UE_LOG(LogPanoramaNVENC, Error, TEXT("nvEncMapInputResource failed (%d)."), static_cast<int32>(Status));
+        AvailableBitstreams.Add(Bitstream);
+        ++Stats.DroppedFrames;
+        return;
+    }
+
+    NV_ENC_PIC_PARAMS PicParams = {};
+    PicParams.version = NV_ENC_PIC_PARAMS_VER;
+    PicParams.inputBuffer = MapParams.mappedResource;
+    PicParams.bufferFmt = GetBufferFormat(Config);
+    PicParams.inputWidth = Config.OutputResolution.X;
+    PicParams.inputHeight = Config.OutputResolution.Y;
+    PicParams.inputPitch = 0;
+    PicParams.outputBitstream = Bitstream;
+    PicParams.pictureStruct = NV_ENC_PIC_STRUCT_FRAME;
+    PicParams.inputTimeStamp = static_cast<uint64>(SubmissionTime * 1000.0);
+
+    const double EncodeStart = FPlatformTime::Seconds();
+
+    NVENCSTATUS EncodeStatus = FunctionList->nvEncEncodePicture(EncoderInterface, &PicParams);
+    FunctionList->nvEncUnmapInputResource(EncoderInterface, MapParams.mappedResource);
+
+    if (EncodeStatus != NV_ENC_SUCCESS)
+    {
+        UE_LOG(LogPanoramaNVENC, Error, TEXT("nvEncEncodePicture failed (%d)."), static_cast<int32>(EncodeStatus));
+        AvailableBitstreams.Add(Bitstream);
+        ++Stats.DroppedFrames;
+        return;
+    }
+
+    DrainBitstream(Bitstream, SubmissionTime);
+
+    const double EncodeEnd = FPlatformTime::Seconds();
+    TotalEncodeLatencySeconds += (EncodeEnd - EncodeStart);
+    ++Stats.EncodedFrames;
+}
+
+void FPanoramaNVENCEncoder::DrainBitstream(void* OutputBitstream, double Timestamp)
+{
+    (void)Timestamp;
+    NV_ENC_LOCK_BITSTREAM LockParams = {};
+    LockParams.version = NV_ENC_LOCK_BITSTREAM_VER;
+    LockParams.outputBitstream = OutputBitstream;
+    LockParams.doNotWait = 0;
+
+    if (NVENCSTATUS Status = FunctionList->nvEncLockBitstream(EncoderInterface, &LockParams); Status == NV_ENC_SUCCESS)
+    {
+        if (ElementaryStreamWriter && LockParams.bitstreamSizeInBytes > 0)
+        {
+            ElementaryStreamWriter->Serialize(LockParams.bitstreamBufferPtr, LockParams.bitstreamSizeInBytes);
+        }
+        FunctionList->nvEncUnlockBitstream(EncoderInterface, OutputBitstream);
+    }
+    else
+    {
+        UE_LOG(LogPanoramaNVENC, Warning, TEXT("nvEncLockBitstream failed (%d)."), static_cast<int32>(Status));
+    }
+
+    AvailableBitstreams.Add(OutputBitstream);
+}
+
+void FPanoramaNVENCEncoder::FlushPendingTasks()
+{
+    if (LastEncodeTask.IsValid())
+    {
+        FTaskGraphInterface::Get().WaitUntilTaskCompletes(LastEncodeTask);
+        LastEncodeTask = nullptr;
+    }
+}
+
+#endif // PLATFORM_WINDOWS && WITH_PANORAMA_NVENC
+

--- a/Plugins/PanoramaCapture/Source/PanoramaCaptureNVENC/Private/PanoramaCaptureNVENCModule.cpp
+++ b/Plugins/PanoramaCapture/Source/PanoramaCaptureNVENC/Private/PanoramaCaptureNVENCModule.cpp
@@ -1,0 +1,31 @@
+#include "PanoramaCaptureNVENCModule.h"
+
+#include "PanoramaCaptureModule.h"
+#include "NVENCEncoder.h"
+
+DEFINE_LOG_CATEGORY(LogPanoramaNVENC);
+
+IMPLEMENT_MODULE(FPanoramaCaptureNVENCModule, PanoramaCaptureNVENC)
+
+void FPanoramaCaptureNVENCModule::StartupModule()
+{
+#if !WITH_PANORAMA_NVENC
+    UE_LOG(LogPanoramaNVENC, Warning, TEXT("Panorama NVENC module initialized without platform support."));
+#else
+    FPanoramaCaptureModule::Get().RegisterVideoEncoderFactory([]()
+    {
+        return MakeShared<FPanoramaNVENCEncoder, ESPMode::ThreadSafe>();
+    });
+    UE_LOG(LogPanoramaNVENC, Log, TEXT("Panorama NVENC module ready."));
+#endif
+}
+
+void FPanoramaCaptureNVENCModule::ShutdownModule()
+{
+#if WITH_PANORAMA_NVENC
+    if (FPanoramaCaptureModule::IsAvailable())
+    {
+        FPanoramaCaptureModule::Get().UnregisterVideoEncoderFactory();
+    }
+#endif
+}

--- a/Plugins/PanoramaCapture/Source/PanoramaCaptureNVENC/Public/NVENCEncoder.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCaptureNVENC/Public/NVENCEncoder.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "VideoEncoder.h"
+
+class PANORAMACAPTURENVENC_API FPanoramaNVENCEncoder : public IPanoramaVideoEncoder
+{
+public:
+    FPanoramaNVENCEncoder();
+    ~FPanoramaNVENCEncoder();
+
+    virtual bool Initialize(const FPanoramaVideoEncoderConfig& InConfig) override;
+    virtual void EncodeFrame(const FPanoramaVideoEncoderFrame& Frame) override;
+    virtual void Flush() override;
+    virtual bool FinalizeEncoding(FString& OutElementaryStream) override;
+    virtual FPanoramaVideoEncoderStats GetStats() const override;
+
+private:
+    struct FRegisteredResource
+    {
+        FRHITexture* Texture = nullptr;
+        void* RegisteredHandle = nullptr;
+    };
+
+    struct FEncodeSubmission
+    {
+        FPanoramaVideoEncoderFrame Frame;
+    };
+
+    bool InitializeSession();
+    void ShutdownSession();
+    bool RegisterIfNeeded(FRHITexture* Texture, void** OutRegisteredHandle);
+    void EncodeSubmission(const FEncodeSubmission& Submission);
+    void DrainBitstream(void* OutputBitstream, double Timestamp);
+    void FlushPendingTasks();
+
+    FPanoramaVideoEncoderConfig Config;
+    bool bInitialized;
+    bool bUsingD3D12;
+
+    TUniquePtr<class FArchive> ElementaryStreamWriter;
+    TMap<FRHITexture*, FRegisteredResource> RegisteredResources;
+    TArray<void*> AvailableBitstreams;
+    void* EncoderInterface;
+    void* DeviceHandle;
+    struct NV_ENCODE_API_FUNCTION_LIST* FunctionList;
+    void* NvEncLibraryHandle;
+
+    FGraphEventRef LastEncodeTask;
+    mutable FCriticalSection EncodeCriticalSection;
+    FPanoramaVideoEncoderStats Stats;
+    double TotalEncodeLatencySeconds;
+};

--- a/Plugins/PanoramaCapture/Source/PanoramaCaptureNVENC/Public/PanoramaCaptureNVENCModule.h
+++ b/Plugins/PanoramaCapture/Source/PanoramaCaptureNVENC/Public/PanoramaCaptureNVENCModule.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Modules/ModuleInterface.h"
+#include "Modules/ModuleManager.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogPanoramaNVENC, Log, All);
+
+class FPanoramaCaptureNVENCModule : public IModuleInterface
+{
+public:
+    static inline FPanoramaCaptureNVENCModule& Get()
+    {
+        return FModuleManager::LoadModuleChecked<FPanoramaCaptureNVENCModule>(TEXT("PanoramaCaptureNVENC"));
+    }
+
+    static inline bool IsAvailable()
+    {
+        return FModuleManager::Get().IsModuleLoaded(TEXT("PanoramaCaptureNVENC"));
+    }
+
+    virtual void StartupModule() override;
+    virtual void ShutdownModule() override;
+};

--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
-# 555
-2323
+# Panorama Capture Plugin Skeleton
+
+This repository contains a Windows-focused Unreal Engine plugin that delivers the core structure for a high-fidelity 360° panorama capture workflow. The implementation ships with working runtime capture logic, asynchronous PNG readback, audio recording hooks, per-frame timestamp-aware muxing, a live preview window, a scene status billboard, an NVENC encoder facade, and editor tooling targeting UE 5.4–5.6.
+
+## Modules
+
+| Module | Purpose |
+| --- | --- |
+| **PanoramaCapture** | Runtime module providing cubemap rig generation, asynchronous RDG conversion, audio/PNG/NVENC orchestration, and capture controller logic. |
+| **PanoramaCaptureEditor** | Editor-only integrations such as toolbar commands, capture status UI, live preview windowing, and preview toggles. |
+| **PanoramaCaptureNVENC** | NVENC integration layer that registers a hardware encoder factory (Win64 only) and exposes zero-copy submission hooks. |
+
+## Key Runtime Features
+
+* `UCubemapCaptureRigComponent` generates ±X/±Y/±Z `USceneCaptureComponent2D` instances with 90° FOV, supports mono/stereo layouts, and resizes render targets at runtime for sRGB/linear workflows.
+* `UPanoramaCaptureController` coordinates capture sessions, manages a configurable ring buffer, performs asynchronous GPU readbacks, writes PNG frames, records audio through the AudioMixer, updates a preview texture and status billboard, and invokes container assembly via FFmpeg with frame-aligned timestamps.
+* `FCubemapEquirectPass` registers an RDG compute shader (`CubemapToEquirect.usf`) that converts mono or stereo cubemaps (over-under or side-by-side) into equirectangular textures.
+
+## NVENC Integration
+
+The `PanoramaCaptureNVENC` module registers a Win64-only encoder factory with the runtime module. At runtime, `UPanoramaCaptureController` requests an encoder through the shared interface, guaranteeing the runtime module stays platform-agnostic. The facade currently drains submissions on a background task and is prepared for D3D11/D3D12 zero-copy interop.
+
+## Editor Tooling
+
+A custom Level Editor toolbar section exposes:
+
+* Capture toggle button
+* Preview window toggle button and standalone window
+* Live status text (“Idle”, “Recording”, “Dropped Frames”) plus queued/blocked counts
+
+Extend `FPanoramaCaptureEditorModule::HandleToggleCapture` to communicate with runtime capture actors inside PIE or editor worlds.
+
+## Shader Registration
+
+`FPanoramaCaptureModule` registers the plugin shader directory (`/PanoramaCapture`) so the RDG compute shader can be located by the engine.
+
+## Next Steps
+
+1. Replace the FFmpeg command-line call with a built-in muxer that writes MP4/MKV containers directly from UE.
+2. Integrate an actual NVENC submission path (using AVEncoder or the NVENC SDK) to replace the current logging stub.
+3. Expand the editor tooling with viewport previews, Sequencer integration, and configuration panels.
+
+All source is organized under `Plugins/PanoramaCapture`. Use this repository as a baseline when starting a fresh Unreal Engine plugin with advanced panoramic capture requirements.


### PR DESCRIPTION
## Summary
- add a capture status billboard, preview texture updates, and timestamp-aware FFmpeg muxing so the controller keeps audio and video in sync while reporting queue metrics
- implement a dedicated panorama preview window, toolbar button, and control menu toggle in the editor module
- extend the video encoder interface to accept frame structs and update the NVENC backend accordingly, then refresh the README to document the new workflow

## Testing
- not run (Unreal Engine unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d38daab5d483259e43ff1155d76f89